### PR TITLE
Update sqlitedb.m

### DIFF
--- a/code/+did/+implementations/sqlitedb.m
+++ b/code/+did/+implementations/sqlitedb.m
@@ -703,8 +703,8 @@ classdef sqlitedb < did.database %#ok<*TNOW1>
                 return
             end
 
-            % Open the specified filename
-            this_obj.dbid = mksqlite('open',filename);
+            % Open the specified filename. Use 0 to get the next free dbid
+            this_obj.dbid = mksqlite(0, 'open', filename);
 
             % If this is an existing file
             if ~isNew
@@ -769,10 +769,19 @@ classdef sqlitedb < did.database %#ok<*TNOW1>
 
         function close_db(this_obj)
             % Close the database file (ignore any errors)
-            try dbid = this_obj.dbid; catch, return, end %bail out if object is no longer valid
+            
+            try 
+                dbid = this_obj.dbid; 
+            catch
+                % bail out if object is no longer valid
+                return
+            end
+            
             try
-                mksqlite(dbid, 'close');
-                this_obj.dbid = [];
+                if ~isempty(dbid)
+                    mksqlite(dbid, 'close');
+                    this_obj.dbid = [];
+                end
             catch ME
                 warning(ME.message)
             end


### PR DESCRIPTION
Made two changes:
- Open with 0 as first argument to `mksqlite`, ensures a new dbid is returned when opening the database.
- Do not attempt to close a database if the dbid is empty. 

The combination of these two changes fixed a new problem I had where the following failed:
```matlab
D = ndi.dataset.dir('test', char(datasetFolder));
d = D.database_search(ndi.query('','isa','base'));
```

with the following output:
```matlab
Warning: Database is in an incosistent state - reopening 
> In did.implementations/sqlitedb/run_sql_noOpen (line 757)
In did.implementations/sqlitedb/do_run_sql_query (line 99)
In did/database/run_sql_query (line 713)
In did.implementations/sqlitedb/do_get_branch_ids (line 114)
In did/database/all_branch_ids (line 156)
In did/database/validate_branch_id (line 1004)
In did/database/search (line 758)
In ndi.database.implementations.database/didsqlite/do_search (line 81)
In ndi/database/search (line 230)
In ndi/session/database_search (line 328)
In ndi/dataset/database_search (line 350) 
> In did.implementations/sqlitedb/run_sql_noOpen (line 758)
In did.implementations/sqlitedb/do_run_sql_query (line 99)
In did/database/run_sql_query (line 713)
In did.implementations/sqlitedb/do_get_branch_ids (line 114)
In did/database/all_branch_ids (line 156)
In did/database/validate_branch_id (line 1004)
In did/database/search (line 758)
In ndi.database.implementations.database/didsqlite/do_search (line 81)
In ndi/database/search (line 230)
In ndi/session/database_search (line 328)
In ndi/dataset/database_search (line 350)
Error running the following SQL query in SQLite DB:
SELECT DISTINCT branch_id FROM branches
Error cause: database not open
Error using mksqlite
database not open

Error in did.implementations.sqlitedb/run_sql_noOpen (line 760)
                    data = mksqlite(this_obj.dbid, query_str, varargin{:});

Error in did.implementations.sqlitedb/do_run_sql_query (line 99)
            data = this_obj.run_sql_noOpen(query_str);

Error in did.database/run_sql_query (line 713)
            data = do_run_sql_query(sqlitedb_obj, query_str);

Error in did.implementations.sqlitedb/do_get_branch_ids (line 114)
            data = this_obj.run_sql_query('SELECT DISTINCT branch_id FROM branches');

Error in did.database/all_branch_ids (line 156)
            branch_ids = database_obj.do_get_branch_ids();

Error in did.database/validate_branch_id (line 1004)
                branch_ids = database_obj.all_branch_ids();

Error in did.database/search (line 758)
            branch_id = database_obj.validate_branch_id(branch_id);

Error in ndi.database.implementations.database.didsqlite/do_search (line 81)
            [doc_ids] = ndi_didsqlite_obj.db.search(searchparams,'a');

Error in ndi.database/search (line 230)
            [ndi_document_objs] = ndi_database_obj.do_search(searchOptions,searchparams);

Error in ndi.session/database_search (line 328)
            ndi_document_obj = ndi_session_obj.database.search(searchparameters);

Error in ndi.dataset/database_search (line 350)
            ndi_document_obj = ndi_dataset_obj.session.database_search(searchparameters);
 
```