### PR TITLE
fix for cellstrs becoming blobs

### DIFF
--- a/code/+did/+implementations/doc2sql.m
+++ b/code/+did/+implementations/doc2sql.m
@@ -115,6 +115,11 @@ end
 function colData = newColumn(name, value, matlabType)
     if nargin < 3, matlabType = class(value); end
     colData.name       = name;
+    if iscellstr(value)&~isempty(value)  % cell arrays of strings are now coming through as BLOBs, not sure why, this makes them comma separated strings as they used to be
+        newvalue = char(join(value,','));
+        if nargin < 3, matlabType = class(newvalue); end
+        value = newvalue;
+    end
     colData.matlabType = matlabType;
     colData.sqlType    = sqlTypeOf(matlabType);
     colData.value      = value;


### PR DESCRIPTION
I have an odd error..it used to be the case that when a field was a cell array of strings, it went into the SQL database as a comma separated list. I can't find where in the code we used to do this. But data from 1-2 years ago shows this behavior when I view it in the DB Browser for SQLite.

Now, cell arrays of strings go in as BLOBs and they aren't searchable anymore. 

I made a fix here but I'm curious if @ehennestad sees or knows where the change is? No need to look for a long time, but maybe it was among the recent changes. 