### PR TITLE
remove warning that db is not open

### DIFF
--- a/code/+did/+implementations/sqlitedb.m
+++ b/code/+did/+implementations/sqlitedb.m
@@ -829,8 +829,8 @@ classdef sqlitedb < did.database %#ok<*TNOW1>
             % Alert, reopen & retry the query if database was now actually open
             if strcmpi(strtrim(err.message),'database not open')
                 try
-                    warning('DID:SQLITEDB:InvalidDatabaseId', ...
-                        'Database is in an inconsistent state - reopening');
+                    %warning('DID:SQLITEDB:InvalidDatabaseId', ...
+                    %    'Database is in an inconsistent state - reopening');
                     % Reset database id
                     this_obj.dbid = [];
                     this_obj.open_db();


### PR DESCRIPTION
This warning is sort of confusing to our users and it doesn't require any action so I suggest removing it