### PR TITLE
Fix fwrite permission check to allow read-write mode files

### DIFF
--- a/src/did/+did/+file/fileobj.m
+++ b/src/did/+did/+file/fileobj.m
@@ -207,7 +207,7 @@ classdef fileobj < handle
             %
             % See also: FWRITE
 
-            if strcmpi(fileobj_obj.permission(1),'r')
+            if strcmpi(fileobj_obj.permission(1),'r') && ~contains(fileobj_obj.permission,'+')
                 error('DID:File:Fileobj','Cannot use fwrite() method with read-only file');
             end
 


### PR DESCRIPTION
## Summary
Fixed the permission validation logic in the `fwrite()` method to correctly allow write operations on files opened in read-write mode ('+' permission).

## Key Changes
- Updated the permission check in `fileobj.m` to properly handle read-write file modes
- Changed condition from `strcmpi(fileobj_obj.permission(1),'r')` to `strcmpi(fileobj_obj.permission(1),'r') && ~contains(fileobj_obj.permission,'+')`
- This allows `fwrite()` to work on files opened with 'r+' or similar read-write modes, while still preventing writes on strictly read-only files

## Implementation Details
The previous logic would reject any file with 'r' as the first character, even if the permission string contained '+' (indicating read-write access). The fix adds an additional check to ensure the '+' modifier is not present before raising the read-only error, allowing proper write access to files opened in read-write mode.

https://claude.ai/code/session_01KeCX4Vu4JSdtbQ8t93rGdo