### PR TITLE
Implement step 5: queryable_array_elem sidecar for [*] paths

### DIFF
--- a/docs/v2/PLAN.md
+++ b/docs/v2/PLAN.md
@@ -708,3 +708,117 @@ field gets queried.
 
 Next up: step 5 — the `queryable_array_elem` sidecar table for
 `[*]` paths.
+
+### 2026-05-12 — step 5 queryable_array_elem sidecar
+
+Implemented step 5 of §9 on branch
+`claude/add-array-fixtures-v2-CbcV2`.
+
+The previous agent's hand-off flagged that the demo fixtures had no
+array-of-structure queryable fields, so the integration tests
+couldn't exercise the sidecar end-to-end. Step 5 starts with a
+fixture extension and then layers the schema-cache / database /
+query-compiler changes on top.
+
+- `tests/+did2/fixtures/V_gamma/demoArray.json` — new class
+  extending base with a single field `axes` (type `structure`,
+  `mustBeScalar: false`, `queryable: true`) whose element template
+  declares three sub-fields: `name` (char, non-queryable label),
+  `unit` (char, queryable TEXT-affinity), and `size` (integer,
+  queryable INTEGER-affinity). The class exercises both
+  `value_text` and `value_num` sidecar columns from a single
+  fixture.
+
+- `src/did/+did2/+schema/cache.m` — `queryablePaths().array` now
+  returns a struct array with the leaf metadata the database
+  backend needs to populate and the compiler needs to route:
+    `path`           — full `[*]`-bearing dot-path
+                       (e.g., `demoArray.axes[*].unit`).
+    `declaringClass` — class that declares the parent array field.
+    `parentField`    — array-of-structure field name (`axes`).
+    `parentPath`     — class-qualified parent path (`demoArray.axes`).
+    `subField`       — queryable sub-field name (`unit`).
+    `type`           — schema type of the sub-field.
+    `affinity`       — SQLite type affinity (`TEXT` / `REAL` /
+                       `INTEGER`) used to pick the sidecar's
+                       `value_text` vs. `value_num` column.
+  The discovery walk now expects an array-of-structure field to be
+  `mustBeScalar: false`, `type: structure`, `queryable: true`, and
+  to declare its element template under `fields`. Sub-fields are
+  emitted only when they are themselves queryable scalars.
+
+- `src/did/+did2/+database/sqlitedb.m` — `createSchema` installs the
+  `queryable_array_elem(doc_id, path, elem_index, value_text,
+  value_num)` table from §3.3 with foreign-key cascades and the
+  `qae_path_text` / `qae_path_num` / `qae_doc_id` indexes.
+  `addOne` populates the sidecar in the same transaction as the
+  `documents` / `superclasses` / `depends_on` inserts, picking the
+  right value column per path's affinity and skipping empty leaves.
+  Bootstrap caches the array-path definitions alongside the
+  scalar columns and threads both into `compileQuery`.
+  Reconciliation:
+    - The configured array-paths set is recorded in the `meta`
+      table under `queryable_array_paths`, newline-delimited (a
+      sentinel `<none>` covers the empty-set case so the column's
+      `NOT NULL` constraint doesn't depend on mksqlite binding
+      `''` literally).
+    - At open, `reconcileQueryableArrayPaths` compares the stored
+      set to the current one. On a mismatch it wipes the sidecar
+      and re-populates by replaying every stored document body
+      through the new path set, then refreshes the meta row.
+    - `ensureSidecarTable` lazily installs the table when the
+      database predates step 5.
+    - The reconcile path degrades gracefully (no-op) when the
+      bootstrap couldn't resolve the schema cache, so a host
+      that temporarily lacks the schema directory doesn't strip
+      a healthy sidecar.
+
+- `src/did/+did2/+database/compileQuery.m` — new
+  `'QueryableArrayPaths'` name-value option, accepting either the
+  schema-cache struct array (so the affinity travels through) or a
+  cellstr of bare paths (defaults to TEXT affinity). When a
+  scalar `[*]`-leaf's dot-path is in the indexed set, the compiler
+  emits `EXISTS (SELECT 1 FROM queryable_array_elem qae WHERE
+  qae.doc_id = documents.id AND qae.path = ? AND <leaf-predicate>)`
+  against the affinity-appropriate `qae.value_*` column.
+  Negation flips to `NOT EXISTS (...)`, which also matches docs
+  with no rows at that path (preserving the in-memory rule that
+  an unresolvable path under `~op` matches). Paths not in the set
+  still take the `json_each` fallback, so ad-hoc exploration over
+  unindexed array shapes keeps working. `hasmember`,
+  `hasanysubfield_contains_string`, and
+  `hasanysubfield_exact_string` continue to use `json_each`:
+  the sidecar stores one row per (element, queryable sub-field)
+  and can't natively serve correlated multi-sub-field predicates.
+
+- `tests/+did2/+unittest/testSchemaCache.m` — three new tests
+  cover the `.array` struct-array shape, the per-entry leaf
+  metadata (`parentPath`, `subField`, `type`, `affinity`), and
+  the count match against the fixtures.
+- `tests/+did2/+unittest/testCompileQuery.m` — five new tests
+  cover the sidecar EXISTS expansion, the json_each fallback for
+  unindexed paths, the negation flip to `NOT EXISTS`, the
+  numeric-affinity routing to `qae.value_num`, and the
+  regexp pre-filter remaining a permissive `1=1` even when the
+  surrounding subquery narrows to `qae.path = ?`.
+- `tests/+did2/+unittest/testSqliteDb.m` — six integration tests
+  cover sidecar population at insert (TEXT and numeric paths),
+  indexed-`[*]` search routing matching the in-memory evaluator,
+  numeric comparison via `value_num`, `ON DELETE CASCADE`
+  cleanup, the `meta` row tracking the configured path set, and
+  the reconcile-on-mismatch flow rebuilding the sidecar from
+  stored bodies.
+
+`did2.database.sqlitedb` grew a `testHookQueryableArrayPaths`
+helper alongside the existing scalar-column hook, so the unit
+tests can introspect the configured set without round-tripping
+through public methods.
+
+Step 5 leaves the in-memory evaluator and the JSON1 fallback
+both untouched, so the SQL compiler's sidecar path is a routing
+optimisation only: every test that exercises the compiler also
+post-filters through `did2.query.matches`, and any divergence
+between the sidecar pre-filter and the reference evaluator would
+surface as a search-result mismatch immediately.
+
+Next up: step 6 — the v1 → v2 converter (PLAN.md §7).

--- a/src/did/+did2/+database/compileQuery.m
+++ b/src/did/+did2/+database/compileQuery.m
@@ -32,9 +32,12 @@ function [whereSQL, params] = compileQuery(q, opts)
 arguments
     q (1,1) did2.query
     opts.QueryablePaths cell = {}
+    opts.QueryableArrayPaths = []
 end
 
-ctx = struct('queryablePaths', {asPathSet(opts.QueryablePaths)});
+ctx = struct( ...
+    'queryablePaths', {asPathSet(opts.QueryablePaths)}, ...
+    'queryableArrayPaths', {asArrayPathMap(opts.QueryableArrayPaths)});
 [whereSQL, params] = compileSearchstructArray(q.searchstructure, ctx);
 end
 
@@ -47,6 +50,37 @@ for k = 1:numel(paths)
         continue;
     end
     set(p) = true;
+end
+end
+
+function map = asArrayPathMap(arrayDefs)
+% Normalise the QueryableArrayPaths input into a path -> affinity map.
+% Accepts a struct array (one entry per sidecar-indexed path; the
+% schema-cache shape with `.path` and `.affinity`), a cellstr of bare
+% paths (assumes TEXT affinity), or empty for "no indexed array paths."
+map = containers.Map('KeyType', 'char', 'ValueType', 'char');
+if isempty(arrayDefs)
+    return;
+end
+if isstruct(arrayDefs)
+    for k = 1:numel(arrayDefs)
+        p = char(arrayDefs(k).path);
+        if isempty(p)
+            continue;
+        end
+        if isfield(arrayDefs(k), 'affinity') && ~isempty(arrayDefs(k).affinity)
+            map(p) = char(arrayDefs(k).affinity);
+        else
+            map(p) = 'TEXT';
+        end
+    end
+elseif iscell(arrayDefs)
+    for k = 1:numel(arrayDefs)
+        p = char(arrayDefs{k});
+        if ~isempty(p)
+            map(p) = 'TEXT';
+        end
+    end
 end
 end
 
@@ -248,7 +282,8 @@ end
 end
 
 function [sql, params] = compileScalar(op, fieldPath, target, isNeg, ctx)
-% Scalar operators. With `[*]` segments, lowers to EXISTS over json_each.
+% Scalar operators. With `[*]` segments, lowers to EXISTS over json_each
+% (or against the queryable_array_elem sidecar when the path is indexed).
 [stars, prefix, leaf] = splitPathOnStar(fieldPath);
 
 if isempty(stars)
@@ -264,6 +299,11 @@ if isempty(stars)
     return;
 end
 
+if arrayPathIsIndexed(fieldPath, ctx)
+    [sql, params] = compileScalarFromSidecar(op, fieldPath, target, isNeg, ctx);
+    return;
+end
+
 [joinSQL, witnessAlias] = buildArrayJoin(stars);
 witnessExpr = leafValueExpression(witnessAlias, leaf);
 [predicate, params] = scalarPredicate(op, witnessExpr, target);
@@ -273,6 +313,74 @@ if isNeg
     sql = sprintf('(NOT %s)', existsSQL);
 else
     sql = existsSQL;
+end
+end
+
+function tf = arrayPathIsIndexed(fieldPath, ctx)
+% True iff this exact '[*]'-bearing path is in the sidecar set.
+tf = false;
+if ~isfield(ctx, 'queryableArrayPaths')
+    return;
+end
+m = ctx.queryableArrayPaths;
+if ~isa(m, 'containers.Map') || m.Count == 0
+    return;
+end
+tf = m.isKey(fieldPath);
+end
+
+function affinity = arrayPathAffinity(fieldPath, ctx)
+% Look up the declared SQLite affinity for an indexed array path.
+% Defaults to 'TEXT' when the path is present but lacks an affinity.
+affinity = 'TEXT';
+if ~isfield(ctx, 'queryableArrayPaths')
+    return;
+end
+m = ctx.queryableArrayPaths;
+if ~isa(m, 'containers.Map') || ~m.isKey(fieldPath)
+    return;
+end
+v = m(fieldPath);
+if ~isempty(v)
+    affinity = v;
+end
+end
+
+function [sql, params] = compileScalarFromSidecar(op, fieldPath, target, isNeg, ctx)
+% Compile a scalar `[*]` predicate against queryable_array_elem.
+%
+% Positive predicates compile to `EXISTS (SELECT 1 FROM
+% queryable_array_elem qae WHERE qae.doc_id = documents.id
+% AND qae.path = ? AND <predicate>)`. Negation flips to `NOT EXISTS
+% (...)` — which also matches docs with no sidecar rows at this path,
+% preserving the in-memory rule that an unresolvable path under `~op`
+% matches.
+%
+% Operators sqlite cannot express natively (regexp, multi-element
+% exact_number) compile to a permissive `1=1` predicate; the
+% in-memory post-filter in did2.database.sqlitedb.search enforces
+% correctness regardless.
+affinity = arrayPathAffinity(fieldPath, ctx);
+valueExpr = sidecarValueExpression(affinity);
+[predicate, params] = scalarPredicate(op, valueExpr, target);
+inner = sprintf(['SELECT 1 FROM queryable_array_elem qae ' ...
+    'WHERE qae.doc_id = documents.id AND qae.path = ? AND %s'], predicate);
+params = [{fieldPath}, params];
+existsSQL = sprintf('EXISTS (%s)', inner);
+if isNeg
+    sql = sprintf('(NOT %s)', existsSQL);
+else
+    sql = existsSQL;
+end
+end
+
+function expr = sidecarValueExpression(affinity)
+% Pick the right value_* column on queryable_array_elem for an affinity.
+switch upper(char(affinity))
+    case {'REAL', 'INTEGER'}
+        expr = 'qae.value_num';
+    otherwise
+        expr = 'qae.value_text';
 end
 end
 

--- a/src/did/+did2/+database/sqlitedb.m
+++ b/src/did/+did2/+database/sqlitedb.m
@@ -45,6 +45,8 @@ classdef sqlitedb < handle
         schemaCache = []
         queryableScalarColumns = []  % struct array from did2.schema.cache.queryablePaths
         queryableScalarPaths = {}    % cellstr mirror, passed to compileQuery
+        queryableArrayPathDefs = []  % struct array; one per [*]-bearing sub-field
+        queryableArrayPaths = {}     % cellstr mirror, passed to compileQuery
         queryableBootstrapOk (1,1) logical = false
     end
 
@@ -75,6 +77,7 @@ classdef sqlitedb < handle
             else
                 obj.assertSchema();
                 obj.reconcileQueryableColumns();
+                obj.reconcileQueryableArrayPaths();
             end
         end
 
@@ -163,7 +166,8 @@ classdef sqlitedb < handle
                 q (1,1) did2.query
             end
             [whereSQL, params] = did2.database.compileQuery(q, ...
-                'QueryablePaths', obj.queryableScalarPaths);
+                'QueryablePaths', obj.queryableScalarPaths, ...
+                'QueryableArrayPaths', obj.queryableArrayPathDefs);
             sql = ['SELECT id, body FROM documents WHERE ' whereSQL ...
                 ' ORDER BY rowid ASC'];
             rows = mksqlite(obj.dbid, sql, params{:});
@@ -201,20 +205,29 @@ classdef sqlitedb < handle
             %   documents table. Hidden helper for unit tests.
             cols = {obj.queryableScalarColumns.column};
         end
+
+        function paths = testHookQueryableArrayPaths(obj)
+            % testHookQueryableArrayPaths - cellstr of the '[*]'-bearing
+            %   sidecar paths this instance expects in queryable_array_elem.
+            %   Hidden helper for unit tests.
+            paths = obj.queryableArrayPaths;
+        end
     end
 
     % ---- schema bootstrap ----
     methods (Access = private)
         function bootstrapQueryableColumns(obj)
             % Resolve the schema cache and snapshot the queryable scalar
-            % paths once per instance. Failures (missing schema dir,
-            % cache errors) degrade gracefully: queryableBootstrapOk
-            % stays false, the JSON1 fallback path stays in effect,
-            % and reconcileQueryableColumns becomes a no-op (so we
-            % don't strip a healthy DB's q_* columns on a host that
-            % temporarily lacks the schema dir).
+            % and array-iteration paths once per instance. Failures
+            % (missing schema dir, cache errors) degrade gracefully:
+            % queryableBootstrapOk stays false, the JSON1 fallback path
+            % stays in effect, and the reconcile* methods become no-ops
+            % (so we don't strip a healthy DB's q_* columns or sidecar
+            % rows on a host that temporarily lacks the schema dir).
             obj.queryableScalarColumns = obj.emptyColumnStruct();
             obj.queryableScalarPaths = {};
+            obj.queryableArrayPathDefs = obj.emptyArrayPathStruct();
+            obj.queryableArrayPaths = {};
             obj.queryableBootstrapOk = false;
             try
                 cache = obj.resolveSchemaCache();
@@ -223,18 +236,27 @@ classdef sqlitedb < handle
             catch
                 return;
             end
-            if isempty(info) || ~isstruct(info) || ~isfield(info, 'scalar') ...
-                    || isempty(info.scalar)
+            if isempty(info) || ~isstruct(info)
                 return;
             end
-            % Sort deterministically by `column` so the CREATE TABLE,
-            % reconciliation, and tests all see the same order.
-            scalar = info.scalar;
-            cols = {scalar.column};
-            [~, order] = sort(cols);
-            scalar = scalar(order);
-            obj.queryableScalarColumns = scalar;
-            obj.queryableScalarPaths = {scalar.path};
+            if isfield(info, 'scalar') && ~isempty(info.scalar)
+                % Sort deterministically by `column` so the CREATE
+                % TABLE, reconciliation, and tests all see the same
+                % order.
+                scalar = info.scalar;
+                cols = {scalar.column};
+                [~, order] = sort(cols);
+                scalar = scalar(order);
+                obj.queryableScalarColumns = scalar;
+                obj.queryableScalarPaths = {scalar.path};
+            end
+            if isfield(info, 'array') && ~isempty(info.array)
+                arrayDefs = info.array;
+                [~, order] = sort({arrayDefs.path});
+                arrayDefs = arrayDefs(order);
+                obj.queryableArrayPathDefs = arrayDefs;
+                obj.queryableArrayPaths = {arrayDefs.path};
+            end
             obj.queryableBootstrapOk = true;
         end
 
@@ -268,6 +290,20 @@ classdef sqlitedb < handle
                     'CREATE INDEX depends_on_name_value ON depends_on(name, value)');
 
                 mksqlite(obj.dbid, [ ...
+                    'CREATE TABLE queryable_array_elem (' ...
+                    'doc_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,' ...
+                    'path TEXT NOT NULL,' ...
+                    'elem_index INTEGER NOT NULL,' ...
+                    'value_text TEXT,' ...
+                    'value_num REAL)']);
+                mksqlite(obj.dbid, ...
+                    'CREATE INDEX qae_path_text ON queryable_array_elem(path, value_text)');
+                mksqlite(obj.dbid, ...
+                    'CREATE INDEX qae_path_num ON queryable_array_elem(path, value_num)');
+                mksqlite(obj.dbid, ...
+                    'CREATE INDEX qae_doc_id ON queryable_array_elem(doc_id)');
+
+                mksqlite(obj.dbid, [ ...
                     'CREATE TABLE meta (' ...
                     'key TEXT PRIMARY KEY, value TEXT NOT NULL)']);
                 mksqlite(obj.dbid, ...
@@ -276,6 +312,10 @@ classdef sqlitedb < handle
                 mksqlite(obj.dbid, ...
                     'INSERT INTO meta(key, value) VALUES(?, ?)', ...
                     'schema_generation', 'V_gamma');
+                mksqlite(obj.dbid, ...
+                    'INSERT INTO meta(key, value) VALUES(?, ?)', ...
+                    'queryable_array_paths', ...
+                    did2.database.sqlitedb.serialisePathSet(obj.queryableArrayPaths));
 
                 mksqlite(obj.dbid, 'COMMIT');
             catch err
@@ -432,6 +472,196 @@ classdef sqlitedb < handle
                 'column', {}, 'affinity', {});
         end
 
+        function s = emptyArrayPathStruct(~)
+            s = struct('path', {}, 'declaringClass', {}, ...
+                'parentField', {}, 'parentPath', {}, ...
+                'subField', {}, 'type', {}, 'affinity', {});
+        end
+
+        function reconcileQueryableArrayPaths(obj)
+            % Compare the configured queryable array-iteration path set
+            % to the snapshot recorded in the meta table. If they
+            % differ, drop every queryable_array_elem row and rebuild
+            % from the stored document bodies. Skipped when bootstrap
+            % degraded so a host that temporarily lacks the schema
+            % directory doesn't strip a healthy sidecar.
+            if ~obj.queryableBootstrapOk
+                return;
+            end
+            obj.ensureSidecarTable();
+            stored = obj.readArrayPathsMeta();
+            desired = obj.queryableArrayPaths;
+            if isequal(sort(stored(:)'), sort(desired(:)'))
+                return;
+            end
+            obj.repopulateSidecarFromBodies();
+            obj.writeArrayPathsMeta();
+        end
+
+        function ensureSidecarTable(obj)
+            % Create the queryable_array_elem table if it isn't present
+            % yet. Used when reopening a database that was created
+            % before step 5 landed (no sidecar at create time).
+            try
+                mksqlite(obj.dbid, ...
+                    'SELECT 1 FROM queryable_array_elem LIMIT 0');
+                return;
+            catch
+            end
+            mksqlite(obj.dbid, [ ...
+                'CREATE TABLE queryable_array_elem (' ...
+                'doc_id TEXT NOT NULL REFERENCES documents(id) ON DELETE CASCADE,' ...
+                'path TEXT NOT NULL,' ...
+                'elem_index INTEGER NOT NULL,' ...
+                'value_text TEXT,' ...
+                'value_num REAL)']);
+            mksqlite(obj.dbid, ...
+                'CREATE INDEX qae_path_text ON queryable_array_elem(path, value_text)');
+            mksqlite(obj.dbid, ...
+                'CREATE INDEX qae_path_num ON queryable_array_elem(path, value_num)');
+            mksqlite(obj.dbid, ...
+                'CREATE INDEX qae_doc_id ON queryable_array_elem(doc_id)');
+        end
+
+        function paths = readArrayPathsMeta(obj)
+            paths = {};
+            try
+                row = mksqlite(obj.dbid, ...
+                    'SELECT value FROM meta WHERE key = ?', ...
+                    'queryable_array_paths');
+            catch
+                return;
+            end
+            if isempty(row) || isempty(row(1).value)
+                return;
+            end
+            paths = did2.database.sqlitedb.deserialisePathSet(row(1).value);
+        end
+
+        function writeArrayPathsMeta(obj)
+            encoded = did2.database.sqlitedb.serialisePathSet(obj.queryableArrayPaths);
+            mksqlite(obj.dbid, ...
+                'INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)', ...
+                'queryable_array_paths', encoded);
+        end
+
+        function repopulateSidecarFromBodies(obj)
+            % Drop every sidecar row and rebuild from the stored
+            % document bodies under the currently-configured array
+            % path set. O(numDocuments * numArrayPaths * elemsPerArray);
+            % acceptable while DBs are small (see PLAN.md Decision 9).
+            mksqlite(obj.dbid, 'BEGIN IMMEDIATE');
+            try
+                mksqlite(obj.dbid, 'DELETE FROM queryable_array_elem');
+                if isempty(obj.queryableArrayPathDefs)
+                    mksqlite(obj.dbid, 'COMMIT');
+                    return;
+                end
+                rows = mksqlite(obj.dbid, ...
+                    'SELECT id, body FROM documents ORDER BY rowid ASC');
+                for k = 1:numel(rows)
+                    docStruct = jsondecode(rows(k).body);
+                    obj.insertSidecarRowsFromStruct(rows(k).id, docStruct);
+                end
+                mksqlite(obj.dbid, 'COMMIT');
+            catch err
+                try mksqlite(obj.dbid, 'ROLLBACK'); catch, end
+                rethrow(err);
+            end
+        end
+
+        function insertSidecarRowsFromStruct(obj, docId, s)
+            % Walk every configured queryable array path and INSERT one
+            % row per array element into queryable_array_elem.
+            for k = 1:numel(obj.queryableArrayPathDefs)
+                def = obj.queryableArrayPathDefs(k);
+                elems = obj.resolveParentArray(s, def.parentPath);
+                for idx = 1:numel(elems)
+                    elem = obj.elementAt(elems, idx);
+                    if ~isstruct(elem) || ~isfield(elem, def.subField)
+                        continue;
+                    end
+                    value = elem.(def.subField);
+                    if obj.isEmptyLeaf(value)
+                        continue;
+                    end
+                    [textValue, numValue] = obj.coerceLeafValue(value, def.affinity);
+                    mksqlite(obj.dbid, ...
+                        ['INSERT INTO queryable_array_elem' ...
+                         '(doc_id, path, elem_index, value_text, value_num) ' ...
+                         'VALUES(?, ?, ?, ?, ?)'], ...
+                        docId, def.path, idx, textValue, numValue);
+                end
+            end
+        end
+
+        function elems = resolveParentArray(~, s, parentPath)
+            % Navigate a dot-path with no [*] segments down to the value
+            % stored at parentPath. Returns a struct array, cell array
+            % of structs, or [] if the path is unresolvable.
+            elems = [];
+            if isempty(parentPath)
+                return;
+            end
+            parts = strsplit(parentPath, '.');
+            cursor = s;
+            for k = 1:numel(parts)
+                if ~isstruct(cursor) || ~isscalar(cursor) ...
+                        || ~isfield(cursor, parts{k})
+                    return;
+                end
+                cursor = cursor.(parts{k});
+            end
+            elems = cursor;
+        end
+
+        function elem = elementAt(~, container, idx)
+            if iscell(container)
+                elem = container{idx};
+            elseif isstruct(container)
+                elem = container(idx);
+            else
+                elem = [];
+            end
+        end
+
+        function tf = isEmptyLeaf(~, value)
+            if isstring(value)
+                tf = isscalar(value) && strlength(value) == 0;
+            elseif ischar(value)
+                tf = isempty(value);
+            else
+                tf = isempty(value);
+            end
+        end
+
+        function [textValue, numValue] = coerceLeafValue(~, value, affinity)
+            textValue = [];
+            numValue = [];
+            switch affinity
+                case 'TEXT'
+                    if ischar(value)
+                        textValue = value;
+                    elseif isstring(value) && isscalar(value)
+                        textValue = char(value);
+                    else
+                        textValue = jsonencode(value);
+                    end
+                case {'REAL', 'INTEGER'}
+                    if isnumeric(value) && isscalar(value)
+                        numValue = double(value);
+                    elseif islogical(value) && isscalar(value)
+                        numValue = double(value);
+                    end
+                otherwise
+                    if ischar(value) || (isstring(value) && isscalar(value))
+                        textValue = char(value);
+                    elseif isnumeric(value) && isscalar(value)
+                        numValue = double(value);
+                    end
+            end
+        end
+
         function assertSchema(obj)
             try
                 row = mksqlite(obj.dbid, ...
@@ -482,6 +712,8 @@ classdef sqlitedb < handle
                         'INSERT INTO depends_on(doc_id, name, value) VALUES(?, ?, ?)', ...
                         id, deps{k}.name, deps{k}.value);
                 end
+
+                obj.insertSidecarRowsFromStruct(id, s);
 
                 mksqlite(obj.dbid, 'COMMIT');
             catch err
@@ -632,6 +864,34 @@ classdef sqlitedb < handle
     end
 
     methods (Static, Access = private)
+        function out = serialisePathSet(paths)
+            % Encode a cellstr path set as a newline-delimited string.
+            % Newline-joining sidesteps the jsondecode-shape variability
+            % (string array vs char matrix vs cell array) that JSON
+            % would otherwise introduce; queryable paths never contain
+            % newlines themselves. The empty set is stored as the
+            % literal '<none>' sentinel so the meta column's NOT NULL
+            % constraint doesn't trip on a binding-as-NULL of MATLAB ''.
+            if isempty(paths)
+                out = '<none>';
+                return;
+            end
+            out = strjoin(paths(:)', char(10));
+        end
+
+        function paths = deserialisePathSet(text)
+            paths = {};
+            if isempty(text)
+                return;
+            end
+            text = char(text);
+            if strcmp(text, '<none>')
+                return;
+            end
+            parts = strsplit(text, char(10));
+            paths = parts(~cellfun('isempty', parts));
+        end
+
         function out = computeHash(text)
             % Lightweight, dependency-free content hash for body_hash.
             try

--- a/src/did/+did2/+database/sqlitedb.m
+++ b/src/did/+did2/+database/sqlitedb.m
@@ -491,7 +491,7 @@ classdef sqlitedb < handle
             obj.ensureSidecarTable();
             stored = obj.readArrayPathsMeta();
             desired = obj.queryableArrayPaths;
-            if isequal(sort(stored(:)'), sort(desired(:)'))
+            if isequal(sort(stored), sort(desired))
                 return;
             end
             obj.repopulateSidecarFromBodies();

--- a/src/did/+did2/+schema/cache.m
+++ b/src/did/+did2/+schema/cache.m
@@ -212,17 +212,35 @@ classdef cache < handle
             %                  .affinity       SQLite type affinity for
             %                                  the column ('TEXT', 'REAL',
             %                                  or 'INTEGER').
-            %     .array   - cellstr of '[*]'-bearing dot-paths from
-            %                array-of-structure fields. Populated for
-            %                step 5; step 4 only consumes .scalar.
+            %     .array   - struct array; one entry per queryable scalar
+            %                sub-field of an array-of-structure field.
+            %                Each entry has:
+            %                  .path           full '[*]'-bearing dot-path
+            %                                  (e.g., 'demoArray.axes[*].unit').
+            %                  .declaringClass declaring class name.
+            %                  .parentField    the array-of-structure field
+            %                                  name (e.g., 'axes').
+            %                  .parentPath     class-qualified parent path
+            %                                  (e.g., 'demoArray.axes').
+            %                  .subField       the queryable sub-field name
+            %                                  inside each element
+            %                                  (e.g., 'unit').
+            %                  .type           the sub-field's schema type
+            %                                  string.
+            %                  .affinity       SQLite type affinity for the
+            %                                  sub-field ('TEXT', 'REAL',
+            %                                  or 'INTEGER').
             %
             %   Run loadAllSchemas() first if you need a deterministic
             %   set independent of which classes have been touched.
             scalar = struct('path', {}, 'declaringClass', {}, ...
                 'fieldName', {}, 'type', {}, ...
                 'column', {}, 'affinity', {});
-            arrayPaths = {};
-            seenPaths = containers.Map('KeyType', 'char', 'ValueType', 'logical');
+            arrayPaths = struct('path', {}, 'declaringClass', {}, ...
+                'parentField', {}, 'parentPath', {}, ...
+                'subField', {}, 'type', {}, 'affinity', {});
+            seenScalar = containers.Map('KeyType', 'char', 'ValueType', 'logical');
+            seenArray  = containers.Map('KeyType', 'char', 'ValueType', 'logical');
 
             keys = obj.loadedClasses.keys();
             for k = 1:numel(keys)
@@ -235,17 +253,14 @@ classdef cache < handle
                 own = obj.toCellArray(schema.fields);
                 for f = 1:numel(own)
                     fieldDef = own{f};
-                    if ~obj.fieldIsQueryable(fieldDef)
-                        continue;
-                    end
                     fieldName = char(fieldDef.name);
                     fieldType = char(fieldDef.type);
                     path = sprintf('%s.%s', className, fieldName);
                     if obj.fieldIsScalar(fieldDef)
-                        if seenPaths.isKey(path)
+                        if ~obj.fieldIsQueryable(fieldDef) || seenScalar.isKey(path)
                             continue;
                         end
-                        seenPaths(path) = true;
+                        seenScalar(path) = true;
                         scalar(end+1) = struct( ...
                             'path', path, ...
                             'declaringClass', className, ...
@@ -253,13 +268,40 @@ classdef cache < handle
                             'type', fieldType, ...
                             'column', did2.schema.cache.columnNameFor(path), ...
                             'affinity', did2.schema.cache.affinityFor(fieldType)); %#ok<AGROW>
-                    else
-                        arrayPaths{end+1} = sprintf('%s[*]', path); %#ok<AGROW>
+                    elseif strcmp(fieldType, 'structure') ...
+                            && obj.fieldIsQueryable(fieldDef) ...
+                            && isfield(fieldDef, 'fields') ...
+                            && ~isempty(fieldDef.fields)
+                        % Array-of-structure: emit one entry per queryable
+                        % scalar sub-field inside the element template.
+                        subEntries = obj.toCellArray(fieldDef.fields);
+                        for s = 1:numel(subEntries)
+                            subDef = subEntries{s};
+                            if ~obj.fieldIsQueryable(subDef) ...
+                                    || ~obj.fieldIsScalar(subDef)
+                                continue;
+                            end
+                            subName = char(subDef.name);
+                            subType = char(subDef.type);
+                            fullPath = sprintf('%s[*].%s', path, subName);
+                            if seenArray.isKey(fullPath)
+                                continue;
+                            end
+                            seenArray(fullPath) = true;
+                            arrayPaths(end+1) = struct( ...
+                                'path', fullPath, ...
+                                'declaringClass', className, ...
+                                'parentField', fieldName, ...
+                                'parentPath', path, ...
+                                'subField', subName, ...
+                                'type', subType, ...
+                                'affinity', did2.schema.cache.affinityFor(subType)); %#ok<AGROW>
+                        end
                     end
                 end
             end
 
-            paths = struct('scalar', scalar, 'array', {arrayPaths});
+            paths = struct('scalar', {scalar}, 'array', {arrayPaths});
         end
 
         function doc = buildBlankDocument(obj, className)

--- a/src/did/+did2/Contents.m
+++ b/src/did/+did2/Contents.m
@@ -17,8 +17,14 @@
 %   Subpackages
 %     +schema       - schema cache and validation entry points.
 %     +database     - storage backends. Currently `sqlitedb` (sqlite3
-%                     + JSON1 fallback) and `compileQuery` (the JSON1
-%                     SQL compiler). See docs/v2/PLAN.md §3, §9 step 3.
+%                     + JSON1 fallback, with the step-4 generated
+%                     columns for queryable scalars and the step-5
+%                     queryable_array_elem sidecar for queryable
+%                     array-iteration paths) and `compileQuery` (the
+%                     JSON1 SQL compiler that routes scalar leaves to
+%                     the generated columns and `[*]` leaves to the
+%                     sidecar when their dot-path is in the indexed
+%                     set). See docs/v2/PLAN.md §3, §9 steps 3–5.
 %     +convert      - (planned) v1-to-v2 conversion utilities.
 %
 %   Conventions

--- a/tests/+did2/+unittest/testCompileQuery.m
+++ b/tests/+did2/+unittest/testCompileQuery.m
@@ -233,11 +233,77 @@ verifySubstring(testCase, sql, 'json_type(body, ''$.base.name'')');
 end
 
 function testStarPathIgnoresQueryablePaths(testCase)
-% Array-iteration paths use json_each; queryable-paths set should not
-% interfere (step 5 will route these to the queryable_array_elem
-% sidecar).
+% The scalar QueryablePaths set is for non-`[*]` paths only. With no
+% QueryableArrayPaths supplied, `[*]`-bearing paths still expand to
+% json_each, regardless of what's listed in QueryablePaths.
 q = did2.query('demoA.axes[*].name', 'exact_string', 'x');
 [sql, ~] = did2.database.compileQuery(q, ...
     'QueryablePaths', {'demoA.axes[*].name', 'base.name'});
 verifySubstring(testCase, sql, 'json_each(json_extract(body, ''$.demoA.axes''))');
+end
+
+% ---- step 5: routing [*] paths to queryable_array_elem ----
+
+function testIndexedStarPathRoutesToSidecar(testCase)
+% With the path in QueryableArrayPaths, the compiler should emit an
+% EXISTS over queryable_array_elem (qae) instead of a json_each
+% expansion. The path string is bound first, then the predicate target.
+q = did2.query('demoArray.axes[*].unit', 'exact_string', 'um');
+[sql, params] = did2.database.compileQuery(q, ...
+    'QueryableArrayPaths', {'demoArray.axes[*].unit'});
+verifySubstring(testCase, sql, 'FROM queryable_array_elem qae');
+verifySubstring(testCase, sql, 'qae.doc_id = documents.id');
+verifySubstring(testCase, sql, 'qae.path = ?');
+verifySubstring(testCase, sql, 'qae.value_text = ?');
+testCase.verifyFalse(contains(sql, 'json_each'));
+verifyEqual(testCase, params, {'demoArray.axes[*].unit', 'um'});
+end
+
+function testIndexedStarPathFallsBackForUnknownPath(testCase)
+% A `[*]` path not present in QueryableArrayPaths should still use the
+% json_each fallback.
+q = did2.query('demoA.axes[*].name', 'exact_string', 'x');
+[sql, ~] = did2.database.compileQuery(q, ...
+    'QueryableArrayPaths', {'demoArray.axes[*].unit'});
+verifySubstring(testCase, sql, 'json_each(json_extract(body, ''$.demoA.axes''))');
+testCase.verifyFalse(contains(sql, 'queryable_array_elem'));
+end
+
+function testIndexedStarNegationFlipsToNotExists(testCase)
+% Negated leaf becomes NOT EXISTS, which also matches docs with no
+% sidecar rows at this path (preserving the in-memory rule that an
+% unresolvable path under `~op` matches).
+q = did2.query('demoArray.axes[*].unit', '~exact_string', 'um');
+[sql, ~] = did2.database.compileQuery(q, ...
+    'QueryableArrayPaths', {'demoArray.axes[*].unit'});
+verifySubstring(testCase, sql, '(NOT EXISTS');
+verifySubstring(testCase, sql, 'queryable_array_elem qae');
+end
+
+function testIndexedStarNumericAffinityUsesValueNum(testCase)
+% A REAL/INTEGER-affinity path lands on qae.value_num rather than
+% qae.value_text.
+arrayDefs = struct( ...
+    'path', 'demoArray.axes[*].size', 'affinity', 'INTEGER', ...
+    'declaringClass', 'demoArray', 'parentField', 'axes', ...
+    'parentPath', 'demoArray.axes', 'subField', 'size', 'type', 'integer');
+q = did2.query('demoArray.axes[*].size', 'lessthan', 100);
+[sql, params] = did2.database.compileQuery(q, ...
+    'QueryableArrayPaths', arrayDefs);
+verifySubstring(testCase, sql, 'queryable_array_elem qae');
+verifySubstring(testCase, sql, 'CAST(qae.value_num AS REAL) < ?');
+verifyEqual(testCase, params, {'demoArray.axes[*].size', 100});
+end
+
+function testIndexedStarRegexpRoutesPermissivelyToSidecar(testCase)
+% Regexp can't be expressed in sqlite, but we can still narrow on the
+% sidecar's `path = ?`, which is a strictly tighter pre-filter than
+% the json_each fallback's bare `1=1`.
+q = did2.query('demoArray.axes[*].unit', 'regexp', '^um');
+[sql, params] = did2.database.compileQuery(q, ...
+    'QueryableArrayPaths', {'demoArray.axes[*].unit'});
+verifySubstring(testCase, sql, 'queryable_array_elem qae');
+verifySubstring(testCase, sql, 'qae.path = ?');
+verifySubstring(testCase, sql, '1=1');
+verifyEqual(testCase, params, {'demoArray.axes[*].unit'});
 end

--- a/tests/+did2/+unittest/testSchemaCache.m
+++ b/tests/+did2/+unittest/testSchemaCache.m
@@ -248,6 +248,35 @@ expected = {'base.datestamp', 'base.id', 'base.name', 'base.session_id', ...
 verifyEqual(testCase, sort(paths), expected);
 end
 
+function testQueryablePathsArrayListsDemoArraySubfields(testCase)
+% The demoArray fixture declares an `axes` array-of-structure field
+% with two queryable scalar sub-fields (`unit` and `size`).
+cache = testCase.TestData.cache;
+cache.loadAllSchemas();
+info = cache.queryablePaths();
+paths = sort({info.array.path});
+verifyEqual(testCase, paths, ...
+    {'demoArray.axes[*].size', 'demoArray.axes[*].unit'});
+end
+
+function testQueryablePathsArrayLeafMetadata(testCase)
+cache = testCase.TestData.cache;
+cache.loadAllSchemas();
+info = cache.queryablePaths();
+unitEntry = info.array(strcmp({info.array.path}, 'demoArray.axes[*].unit'));
+verifyEqual(testCase, numel(unitEntry), 1);
+verifyEqual(testCase, unitEntry.declaringClass, 'demoArray');
+verifyEqual(testCase, unitEntry.parentField, 'axes');
+verifyEqual(testCase, unitEntry.parentPath, 'demoArray.axes');
+verifyEqual(testCase, unitEntry.subField, 'unit');
+verifyEqual(testCase, unitEntry.type, 'char');
+verifyEqual(testCase, unitEntry.affinity, 'TEXT');
+
+sizeEntry = info.array(strcmp({info.array.path}, 'demoArray.axes[*].size'));
+verifyEqual(testCase, sizeEntry.type, 'integer');
+verifyEqual(testCase, sizeEntry.affinity, 'INTEGER');
+end
+
 function testQueryablePathsColumnNames(testCase)
 cache = testCase.TestData.cache;
 cache.loadAllSchemas();
@@ -269,12 +298,13 @@ info = cache.queryablePaths();
 verifyTrue(testCase, all(strcmp({info.scalar.affinity}, 'TEXT')));
 end
 
-function testQueryablePathsArrayEmptyForFixtures(testCase)
+function testQueryablePathsArrayCountMatchesFixtures(testCase)
+% The demo fixtures declare exactly two queryable array sub-fields,
+% both on demoArray.axes (`unit` and `size`).
 cache = testCase.TestData.cache;
 cache.loadAllSchemas();
 info = cache.queryablePaths();
-% No array-of-structure queryable fields in the demo fixtures.
-verifyEqual(testCase, info.array, {});
+verifyEqual(testCase, numel(info.array), 2);
 end
 
 function testLoadAllSchemasIsIdempotent(testCase)

--- a/tests/+did2/+unittest/testSqliteDb.m
+++ b/tests/+did2/+unittest/testSqliteDb.m
@@ -405,12 +405,16 @@ db.add(doc);
 rows = mksqlite(db.testHookDbId(), ...
     'SELECT path, elem_index, value_text, value_num FROM queryable_array_elem ORDER BY path, elem_index');
 verifyEqual(testCase, numel(rows), 6);
-unitRows = rows(strcmp({rows.path}, 'demoArray.axes[*].unit'));
-verifyEqual(testCase, ...
-    arrayfun(@(r) char(r.value_text), unitRows, 'UniformOutput', false), ...
-    {'um','um','deg'});
-sizeRows = rows(strcmp({rows.path}, 'demoArray.axes[*].size'));
-verifyEqual(testCase, [sizeRows.value_num], [10 20 5]);
+% mksqlite returns N x 1 struct arrays; flatten via comma-list packing so
+% shape mismatches don't trip the equality checks below.
+unitMask = strcmp({rows.path}, 'demoArray.axes[*].unit');
+unitRows = rows(unitMask);
+unitValues = cellfun(@char, {unitRows.value_text}, 'UniformOutput', false);
+verifyEqual(testCase, unitValues, {'um','um','deg'});
+sizeMask = strcmp({rows.path}, 'demoArray.axes[*].size');
+sizeRows = rows(sizeMask);
+sizeValues = [sizeRows.value_num];
+verifyEqual(testCase, sizeValues(:)', [10 20 5]);
 end
 
 function testSidecarRoutesIndexedStarSearch(testCase)

--- a/tests/+did2/+unittest/testSqliteDb.m
+++ b/tests/+did2/+unittest/testSqliteDb.m
@@ -299,6 +299,13 @@ doc = doc.set('demoA.value', valueA);
 doc = doc.set('demoB.value_b', valueB);
 end
 
+function doc = makeDemoArray(name, axes)
+doc = did2.document.blank('demoArray');
+doc = doc.set('base.session_id', sprintf('session-%s', name));
+doc = doc.set('base.name', name);
+doc = doc.set('demoArray.axes', axes);
+end
+
 % ---- step 4: generated columns + rebuild-on-mismatch ----
 
 function testGeneratedColumnsExistAtCreate(testCase)
@@ -383,6 +390,106 @@ for k = 1:numel(candidates)
         % column does not exist on this table.
     end
 end
+end
+
+% ---- step 5: queryable_array_elem sidecar ----
+
+function testSidecarPopulatedAtInsert(testCase)
+% A demoArray document with three axes should yield three sidecar rows
+% for each queryable sub-field path.
+db = testCase.TestData.db;
+axes = struct('name', {'x','y','z'}, 'unit', {'um','um','deg'}, ...
+    'size', {10, 20, 5});
+doc = makeDemoArray('layered', axes);
+db.add(doc);
+rows = mksqlite(db.testHookDbId(), ...
+    'SELECT path, elem_index, value_text, value_num FROM queryable_array_elem ORDER BY path, elem_index');
+verifyEqual(testCase, numel(rows), 6);
+unitRows = rows(strcmp({rows.path}, 'demoArray.axes[*].unit'));
+verifyEqual(testCase, ...
+    arrayfun(@(r) char(r.value_text), unitRows, 'UniformOutput', false), ...
+    {'um','um','deg'});
+sizeRows = rows(strcmp({rows.path}, 'demoArray.axes[*].size'));
+verifyEqual(testCase, [sizeRows.value_num], [10 20 5]);
+end
+
+function testSidecarRoutesIndexedStarSearch(testCase)
+% A search on the indexed array path should hit the sidecar and return
+% the same docs as the in-memory evaluator.
+db = testCase.TestData.db;
+ax1 = struct('name', {'x','y'}, 'unit', {'um','um'}, 'size', {1, 2});
+ax2 = struct('name', {'x'},     'unit', {'deg'},     'size', {3});
+d1 = makeDemoArray('d1', ax1); db.add(d1);
+d2 = makeDemoArray('d2', ax2); db.add(d2);
+hits = db.search(did2.query('demoArray.axes[*].unit', 'exact_string', 'deg'));
+verifyEqual(testCase, numel(hits), 1);
+verifyEqual(testCase, hits{1}.get('base.id'), d2.get('base.id'));
+end
+
+function testSidecarNumericComparisonRoutes(testCase)
+% lessthan against the INTEGER-affinity `size` sub-field should land
+% on value_num via the sidecar and select the right doc.
+db = testCase.TestData.db;
+big = struct('name', {'x'}, 'unit', {'um'}, 'size', {1000});
+small = struct('name', {'x'}, 'unit', {'um'}, 'size', {5});
+d1 = makeDemoArray('big',   big);   db.add(d1);
+d2 = makeDemoArray('small', small); db.add(d2);
+hits = db.search(did2.query('demoArray.axes[*].size', 'lessthan', 10));
+verifyEqual(testCase, numel(hits), 1);
+verifyEqual(testCase, hits{1}.get('base.name'), 'small');
+end
+
+function testSidecarRemovedOnDocDelete(testCase)
+% Deleting the document should cascade to queryable_array_elem.
+db = testCase.TestData.db;
+axes = struct('name', {'x'}, 'unit', {'um'}, 'size', {7});
+doc = makeDemoArray('delme', axes);
+db.add(doc);
+docId = doc.get('base.id');
+preRows = mksqlite(db.testHookDbId(), ...
+    'SELECT COUNT(*) AS n FROM queryable_array_elem WHERE doc_id = ?', docId);
+verifyEqual(testCase, double(preRows(1).n), 2);
+db.remove(docId);
+postRows = mksqlite(db.testHookDbId(), ...
+    'SELECT COUNT(*) AS n FROM queryable_array_elem WHERE doc_id = ?', docId);
+verifyEqual(testCase, double(postRows(1).n), 0);
+end
+
+function testSidecarMetaTracksPathSet(testCase)
+% The configured array-paths set should be recorded in the meta table
+% so the next open can detect a mismatch.
+db = testCase.TestData.db;
+row = mksqlite(db.testHookDbId(), ...
+    'SELECT value FROM meta WHERE key = ?', 'queryable_array_paths');
+verifyEqual(testCase, numel(row), 1);
+parts = strsplit(char(row(1).value), char(10));
+expected = {'demoArray.axes[*].size', 'demoArray.axes[*].unit'};
+verifyEqual(testCase, sort(parts), expected);
+end
+
+function testSidecarReconcileRepopulates(testCase)
+% Manually clobber the sidecar's path set in `meta` and wipe its rows
+% to simulate a previous schema generation. Reopening should rebuild
+% the sidecar from the stored bodies under the current path set.
+db = testCase.TestData.db;
+axes = struct('name', {'x','y'}, 'unit', {'um','deg'}, 'size', {1, 2});
+doc = makeDemoArray('reb', axes);
+db.add(doc);
+docId = doc.get('base.id');
+mksqlite(db.testHookDbId(), 'DELETE FROM queryable_array_elem');
+mksqlite(db.testHookDbId(), ...
+    'INSERT OR REPLACE INTO meta(key, value) VALUES(?, ?)', ...
+    'queryable_array_paths', 'stale.other[*].field');
+db.close();
+
+db2 = did2.database.sqlitedb(testCase.TestData.tmpFile);
+cleanup = onCleanup(@() db2.close()); %#ok<NASGU>
+rows = mksqlite(db2.testHookDbId(), ...
+    'SELECT COUNT(*) AS n FROM queryable_array_elem WHERE doc_id = ?', docId);
+verifyEqual(testCase, double(rows(1).n), 4);
+% A search on the indexed path now goes through the rebuilt sidecar.
+hits = db2.search(did2.query('demoArray.axes[*].unit', 'exact_string', 'deg'));
+verifyEqual(testCase, numel(hits), 1);
 end
 
 function ok = tryDropColumn(dbid, table, column)

--- a/tests/+did2/fixtures/V_gamma/demoArray.json
+++ b/tests/+did2/fixtures/V_gamma/demoArray.json
@@ -1,0 +1,75 @@
+{
+    "document_class": {
+        "class_name": "demoArray",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base",
+                "schema": "$DIDSCHEMAPATH/base.json"
+            }
+        ],
+        "maturity_level": "work_in_progress"
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "axes",
+            "type": "structure",
+            "blank_value": [],
+            "default_value": [],
+            "mustBeNonEmpty": false,
+            "mustBeScalar": false,
+            "mustNotHaveNaN": false,
+            "queryable": true,
+            "ontology": null,
+            "documentation": "Array of axis descriptors used by the +did2 self-tests to exercise queryable array-of-structure sub-fields (PLAN.md §3.3).",
+            "constraints": {},
+            "fields": [
+                {
+                    "name": "name",
+                    "type": "char",
+                    "blank_value": "",
+                    "default_value": "",
+                    "mustBeNonEmpty": false,
+                    "mustBeScalar": true,
+                    "mustNotHaveNaN": false,
+                    "queryable": false,
+                    "ontology": null,
+                    "documentation": "Human-readable axis label (not queryable).",
+                    "constraints": {
+                        "maxLength": 64
+                    }
+                },
+                {
+                    "name": "unit",
+                    "type": "char",
+                    "blank_value": "",
+                    "default_value": "",
+                    "mustBeNonEmpty": false,
+                    "mustBeScalar": true,
+                    "mustNotHaveNaN": false,
+                    "queryable": true,
+                    "ontology": null,
+                    "documentation": "Per-axis unit string. Queryable: drives the queryable_array_elem sidecar in tests.",
+                    "constraints": {
+                        "maxLength": 64
+                    }
+                },
+                {
+                    "name": "size",
+                    "type": "integer",
+                    "blank_value": 0,
+                    "default_value": 0,
+                    "mustBeNonEmpty": false,
+                    "mustBeScalar": true,
+                    "mustNotHaveNaN": false,
+                    "queryable": true,
+                    "ontology": null,
+                    "documentation": "Number of samples along the axis. Queryable numeric sub-field used by the value_num sidecar path.",
+                    "constraints": {}
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

This PR implements step 5 of the queryable array-iteration path optimization (PLAN.md §9), adding a `queryable_array_elem` sidecar table to index scalar sub-fields of array-of-structure fields. This enables efficient SQL queries on `[*]`-bearing paths without falling back to JSON1's `json_each`.

## Key Changes

### Schema & Fixtures
- **New fixture `demoArray.json`**: Extends the test schema with an `axes` array-of-structure field containing two queryable sub-fields (`unit` as TEXT, `size` as INTEGER) to exercise both value columns of the sidecar.

### Database Backend (`sqlitedb.m`)
- **New `queryable_array_elem` table**: Stores `(doc_id, path, elem_index, value_text, value_num)` with foreign-key cascades and three indexes (`qae_path_text`, `qae_path_num`, `qae_doc_id`).
- **Bootstrap & caching**: Extended `bootstrapQueryableColumns` to discover and cache array-path definitions from the schema cache alongside scalar columns.
- **Sidecar population**: `addOne` now inserts sidecar rows in the same transaction as document storage, routing values to `value_text` or `value_num` based on declared affinity.
- **Reconciliation**: New `reconcileQueryableArrayPaths` method compares the configured array-path set (stored in `meta` table) to the current one; on mismatch, wipes and rebuilds the sidecar from stored document bodies. Degrades gracefully when schema cache is unavailable.
- **Lazy table creation**: `ensureSidecarTable` handles databases created before step 5 landed.
- **Helper methods**: `insertSidecarRowsFromStruct`, `resolveParentArray`, `elementAt`, `isEmptyLeaf`, `coerceLeafValue` handle the mechanics of walking document structures and coercing values to the appropriate SQL column.
- **Serialization**: `serialisePathSet` / `deserialisePathSet` encode the path set as newline-delimited strings for the `meta` table (with `<none>` sentinel for empty sets).

### Query Compiler (`compileQuery.m`)
- **New `QueryableArrayPaths` option**: Accepts either a struct array (schema-cache shape with `.path` and `.affinity`) or a cellstr of bare paths (defaults to TEXT affinity).
- **Sidecar routing**: When a `[*]`-bearing path is in the indexed set, `compileScalarFromSidecar` emits `EXISTS (SELECT 1 FROM queryable_array_elem qae WHERE qae.doc_id = documents.id AND qae.path = ? AND <predicate>)` against the affinity-appropriate `qae.value_*` column.
- **Negation handling**: Negated predicates flip to `NOT EXISTS`, preserving the in-memory rule that unresolvable paths under `~op` match.
- **Fallback**: Paths not in the indexed set still use `json_each`, so ad-hoc exploration over unindexed array shapes remains functional.
- **Unsupported operators**: Regexp and multi-element exact_number compile to a permissive `1=1` predicate; the in-memory post-filter enforces correctness.

### Schema Cache (`cache.m`)
- **Array-path discovery**: `queryablePaths().array` now returns a struct array with per-entry metadata: `path`, `declaringClass`, `parentField`, `parentPath`, `subField`, `type`, and `affinity`.
- **Validation**: Array-of-structure fields must be `mustBeScalar: false`, `type: structure`, `queryable: true`, with an element template under `fields`. Only queryable scalar sub-fields are emitted.

### Tests
- **`testSqliteDb.m`**: Six integration tests cover sidecar population at insert (TEXT and numeric paths), indexed-`[*]` search routing, numeric comparison via `value_num`, `ON DELETE CASCADE` cleanup, meta-table tracking, and reconc

https://claude.ai/code/session_01P16GzfkTcs9QkqATAnhgiJ