### PR TITLE
v2 step 6 readers: v1 DB readers + fromV1Database orchestrator

### DIFF
--- a/docs/v2/PLAN.md
+++ b/docs/v2/PLAN.md
@@ -1168,3 +1168,109 @@ What remains in step 6 after this PR:
   migrator implementations are mechanical from there.
 
 Next up: 6d.
+
+
+### 2026-05-14 — step 6 readers: v1 DB readers + fromV1Database
+
+Landed on branch `claude/v2-update-step-6-readers-qhmu3` after the
+6a + 6c PR (#126) merged into V2. Adds the input side of the
+converter so a real legacy v1 DID database (sqlite or
+matlabdumbjsondb) can be opened, every document body read out as
+raw JSON, and the whole batch piped through
+`did2.convert.v1_to_v2` into a fresh v2 sqlitedb file. Closes
+the "tool that opens NDI datasets or sessions, grabs all the
+documents in JSON, and runs the conversion tool" line of work
+from the architecture discussion in conversation. The NDI-layer
+wrapper (a `ndi.convert.session(S, dstPath)` shim) is
+deliberately kept out of `+did2` and lives in NDI-matlab to keep
+`+did2` namespace-clean.
+
+Added under `src/did/+did2/+convert/`:
+
+- **`+readers/sqliteV1.m`** — reader for `did.implementations.sqlitedb`
+  files. Opens the .sqlite via mksqlite (the same MEX +did2's own
+  storage already requires), runs `SELECT json_code FROM docs`, and
+  returns the bodies as a cellstr. The v1 schema was discovered by
+  reading `src/did/+did/+implementations/sqlitedb.m`:
+    - documents table: `docs(doc_id TEXT UNIQUE, doc_idx INTEGER
+      AUTOINCREMENT PK, timestamp NUMERIC, json_code TEXT)`
+    - other v1 tables (`branches`, `branch_docs`, `doc_data`,
+      `fields`, `files`) are out of scope at this layer; the
+      reader is body-level only.
+  Errors flow through `did2:convert:readerFailed` (e.g. file
+  missing, table missing, mksqlite missing).
+
+- **`+readers/dumbJsonV1.m`** — reader for `matlabdumbjsondb`
+  directories. Walks `<dbdir>/{.dumbjsondb,dumbjsondb}/` for the
+  `Object_id_<ID>_v<HEX5>.json` body files, picks the highest-version
+  body per id (matching `latestdocversion` semantics), and returns
+  the bodies as a cellstr. Layout discovered by reading
+  `src/did/+did/+implementations/matlabdumbjsondb.m` +
+  `src/did/+did/+file/dumbjsondb.m`:
+    - `Object_id_<ID>_v<HEX5>.json` — document JSON body
+      (`HEX5 = dec2hex(version, 5)`).
+    - `Object_id_<ID>.txt` — meta file pointing at the latest
+      version number.
+    - `Object_id_<ID>_v<HEX5>.json.binary` — associated binary
+      file (touched empty by default; out of scope for this layer).
+
+- **`fromV1Database.m`** — the end-to-end orchestrator. Sniffs
+  `srcPath`:
+    - file path -> `sqliteV1` reader,
+    - directory -> `dumbJsonV1` reader,
+    - anything else -> `did2:convert:badSourcePath`.
+  Pipes the bodies through `did2.convert.v1_to_v2`, inserts the
+  successful `did2.document` instances into a fresh
+  `did2.database.sqlitedb` at `dstPath`, and writes the
+  quarantine struct array (if any) to `<dstPath>.quarantine.json`
+  via `jsonencode`. Refuses to overwrite an existing `dstPath`
+  unless `Overwrite=true` is passed. Returns the same
+  `{migrated, quarantine, summary}` struct that `v1_to_v2`
+  returns. Name-value options: `Validate` (default true),
+  `SchemaCache` (default []), `Verbose` (default false),
+  `Overwrite` (default false).
+
+Tests landed alongside:
+
+- `tests/+did2/+unittest/testReaders.m` — synthesises tiny v1
+  databases in tempfiles for both flavours and asserts the
+  readers return the expected bodies. Covers empty databases,
+  empty directories, the highest-version-wins rule for the
+  dumbjsondb reader, and the malformed-source error paths.
+  Gated via `assumeFail` when mksqlite is not on the MATLAB
+  path (matches the existing `testSqliteDb` pattern).
+- `tests/+did2/+unittest/testFromV1Database.m` — end-to-end
+  tests through the orchestrator: build a synthetic v1 sqlite
+  source, run `fromV1Database` to a tempfile v2 sqlite, verify
+  every doc round-trips and `summary.migrated_count` matches;
+  same for a dumbjsondb source; verify quarantine on a
+  malformed input lands in `<dstPath>.quarantine.json`; verify
+  `Overwrite=false` (default) refuses an existing dst and
+  `Overwrite=true` proceeds. Tests use `'Validate', false` so
+  they do not depend on a checked-out did-schema directory.
+
+Updates `src/did/+did2/+convert/Contents.m` to document the
+new `+readers` subpackage and the `fromV1Database` entry. New
+`+readers/Contents.m` file documents the reader convention.
+
+Files in v1 docs — deliberate out-of-scope follow-up:
+
+V1 DID documents whose body contains a populated `files.file_info`
+array reference binary blobs that live in the v1
+database's `<dbdir>/files/<uid>` cache (for sqlitedb) or in
+`Object_id_<ID>_v<HEX5>.json.binary` sidecars (for dumbjsondb).
+The readers ignore these blobs entirely — they only return the
+body JSON. A future pass needs to (a) copy the file blobs into
+a v2 file store and (b) ensure migrators preserve the `files`
+block in the body so v2 docs can resolve their attachments. In
+practice this affects image-flavoured / raw-data classes (e.g.
+`ontology_image` and NDI subclasses like `epoch`, `element`).
+
+No tests were run locally — the authoring environment has no
+MATLAB. CI will verify on merge.
+
+Next up: 6d (CI test data pipeline). With the readers in place,
+6d can wire a real ~16 MB v1 NDI sqlite into the per-PR
+`integration-small` job and feed it through `fromV1Database`
+end-to-end, asserting zero quarantine rows + a small set of
+golden queries against the v2 result.

--- a/src/did/+did2/+convert/+readers/Contents.m
+++ b/src/did/+did2/+convert/+readers/Contents.m
@@ -1,0 +1,20 @@
+% +readers  Raw-body readers for legacy did_v1 databases.
+%
+%   The +readers subpackage exposes pure-read entry points that pull
+%   the raw document JSON bodies out of the two v1 DID database
+%   storage formats. Neither reader instantiates the corresponding
+%   did.database subclass (those classes run their own validation and
+%   maintain on-disk cache folders); both return a cellstr of JSON
+%   strings suitable for piping into did2.convert.v1_to_v2.
+%
+%   Files
+%     sqliteV1     - opens a v1 did.implementations.sqlitedb file via
+%                    mksqlite and returns the `docs.json_code` column
+%                    as a cellstr of raw JSON bodies.
+%     dumbJsonV1   - walks a v1 did.implementations.matlabdumbjsondb
+%                    directory (Object_id_*_v#####.json files) and
+%                    returns the JSON contents as a cellstr, keeping
+%                    only the latest version per document id.
+%
+%   See also: did2.convert.fromV1Database, did2.convert.v1_to_v2,
+%             docs/v2/PLAN.md §9.6.

--- a/src/did/+did2/+convert/+readers/dumbJsonV1.m
+++ b/src/did/+did2/+convert/+readers/dumbJsonV1.m
@@ -1,0 +1,117 @@
+function bodies = dumbJsonV1(srcDir)
+%DUMBJSONV1 Read raw v1 document JSON bodies from a legacy dumbjsondb tree.
+%
+%   BODIES = did2.convert.readers.dumbJsonV1(SRCDIR) walks a directory
+%   produced by did.file.dumbjsondb (used by did.implementations.matlabdumbjsondb)
+%   and returns the JSON document files verbatim as a cellstr column
+%   vector. Documents are matched by the on-disk filename pattern
+%   `Object_id_*_v<HHHHH>.json`, where the trailing five-hex token is
+%   the version. For each unique document id this reader returns only
+%   the latest (numerically maximum) version; older versions are
+%   ignored so the downstream migrator sees the same document body
+%   that did.file.dumbjsondb.read() would have served.
+%
+%   The reader looks for `.json` files directly under SRCDIR, and also
+%   under one level of common subdirectories the dumbjsondb writer
+%   uses (e.g. `.dumbjsondb` or `dumbjsondb`). It does NOT recurse
+%   beyond that — the v1 layout is intentionally flat.
+%
+%   Errors:
+%     did2:convert:readerFailed   - SRCDIR missing, or a matched file
+%                                   could not be read.
+%
+%   See also: did2.convert.readers.sqliteV1,
+%             did2.convert.fromV1Database.
+
+arguments
+    srcDir (1,:) char
+end
+
+if ~isfolder(srcDir)
+    error('did2:convert:readerFailed', ...
+        'v1 dumbjsondb source "%s" is not a directory.', srcDir);
+end
+
+searchDirs = candidateDirs(srcDir);
+matches = struct('name', {}, 'folder', {}, 'id', {}, 'version', {});
+
+for d = 1:numel(searchDirs)
+    listing = dir(fullfile(searchDirs{d}, 'Object_id_*_v*.json'));
+    for k = 1:numel(listing)
+        entry = listing(k);
+        if entry.isdir
+            continue;
+        end
+        [id, versionHex] = parseDumbJsonName(entry.name);
+        if isempty(id) || isempty(versionHex)
+            continue;
+        end
+        try
+            versionNum = hex2dec(versionHex);
+        catch
+            continue;
+        end
+        matches(end+1) = struct( ...
+            'name',    entry.name, ...
+            'folder',  entry.folder, ...
+            'id',      id, ...
+            'version', versionNum); %#ok<AGROW>
+    end
+end
+
+if isempty(matches)
+    bodies = cell(0, 1);
+    return;
+end
+
+% Keep only the latest version per id (the dumbjsondb on-disk layout
+% retains older versions side-by-side; the public read() returns the
+% highest, so we match that).
+ids = {matches.id};
+[uniqueIds, ~, groupIdx] = unique(ids);
+keepIndices = zeros(numel(uniqueIds), 1);
+for g = 1:numel(uniqueIds)
+    members = find(groupIdx == g);
+    versions = [matches(members).version];
+    [~, localMax] = max(versions);
+    keepIndices(g) = members(localMax);
+end
+selected = matches(keepIndices);
+
+bodies = cell(numel(selected), 1);
+for k = 1:numel(selected)
+    fullPath = fullfile(selected(k).folder, selected(k).name);
+    try
+        bodies{k} = fileread(fullPath);
+    catch err
+        error('did2:convert:readerFailed', ...
+            'Failed to read "%s": %s', fullPath, err.message);
+    end
+end
+end
+
+function dirs = candidateDirs(root)
+% The dumbjsondb writer stores docs in <paramfile_dir>/<dirname>/.
+% Callers typically pass either the paramfile directory or the inner
+% data directory; accept both shapes plus the two common dirnames.
+dirs = {root};
+inner = {'.dumbjsondb', 'dumbjsondb'};
+for k = 1:numel(inner)
+    candidate = fullfile(root, inner{k});
+    if isfolder(candidate)
+        dirs{end+1} = candidate; %#ok<AGROW>
+    end
+end
+end
+
+function [id, versionHex] = parseDumbJsonName(filename)
+id = '';
+versionHex = '';
+tokens = regexp(filename, '^Object_id_(.+)_v([0-9A-Fa-f]+)\.json$', ...
+    'tokens', 'once');
+if isempty(tokens)
+    return;
+end
+id = tokens{1};
+versionHex = tokens{2};
+end

--- a/src/did/+did2/+convert/+readers/sqliteV1.m
+++ b/src/did/+did2/+convert/+readers/sqliteV1.m
@@ -1,0 +1,91 @@
+function bodies = sqliteV1(srcPath)
+%SQLITEV1 Read raw v1 document JSON bodies from a legacy DID SQLite file.
+%
+%   BODIES = did2.convert.readers.sqliteV1(SRCPATH) opens the legacy v1
+%   DID SQLite database at SRCPATH (the format implemented by
+%   did.implementations.sqlitedb), reads every row of the `docs` table,
+%   and returns the `json_code` column as a cellstr column vector of
+%   raw JSON bodies. Nothing is decoded here; downstream consumers
+%   (e.g. did2.convert.v1_to_v2) handle parsing.
+%
+%   The function is pure-read: it does NOT instantiate
+%   did.implementations.sqlitedb (which would run validation, create a
+%   cache folder, etc.). The database is opened directly via mksqlite
+%   and closed before this function returns.
+%
+%   Errors:
+%     did2:convert:readerFailed   - mksqlite missing, file unreadable,
+%                                   or the `docs.json_code` column not
+%                                   found in SRCPATH.
+%
+%   See also: did2.convert.readers.dumbJsonV1,
+%             did2.convert.fromV1Database.
+
+arguments
+    srcPath (1,:) char
+end
+
+if isempty(which('mksqlite'))
+    error('did2:convert:readerFailed', ...
+        ['mksqlite is required to read a v1 SQLite database. ' ...
+         'Install https://github.com/a-ma72/mksqlite and put it on the path.']);
+end
+
+if ~isfile(srcPath)
+    error('did2:convert:readerFailed', ...
+        'v1 sqlite source "%s" does not exist.', srcPath);
+end
+
+try
+    dbid = mksqlite(0, 'open', srcPath);
+catch err
+    error('did2:convert:readerFailed', ...
+        'Failed to open "%s" as a sqlite database: %s', srcPath, err.message);
+end
+% Box the handle so the closure sees mutations, then null it out once
+% we've explicitly closed (preventing a double-close in the cleanup hook).
+handle = struct('id', dbid);
+cleanup = onCleanup(@() closeIfOpen(handle)); %#ok<NASGU>
+
+try
+    rows = mksqlite(dbid, 'SELECT json_code FROM docs');
+catch err
+    error('did2:convert:readerFailed', ...
+        ['Failed to read docs.json_code from "%s": %s. ' ...
+         'Is this a did.implementations.sqlitedb file?'], ...
+        srcPath, err.message);
+end
+
+if isempty(rows)
+    bodies = cell(0, 1);
+    return;
+end
+
+bodies = cell(numel(rows), 1);
+for k = 1:numel(rows)
+    body = rows(k).json_code;
+    if iscell(body)
+        if isempty(body)
+            body = '';
+        else
+            body = body{1};
+        end
+    end
+    if isstring(body)
+        body = char(body);
+    end
+    if isempty(body)
+        body = '';
+    end
+    bodies{k} = body;
+end
+end
+
+function closeIfOpen(handle)
+if ~isempty(handle) && isfield(handle, 'id') && ~isempty(handle.id)
+    try
+        mksqlite(handle.id, 'close');
+    catch
+    end
+end
+end

--- a/src/did/+did2/+convert/Contents.m
+++ b/src/did/+did2/+convert/Contents.m
@@ -2,10 +2,20 @@
 %
 %   The +convert subpackage implements PLAN.md §7 plus the step-6
 %   sub-steps in §9.6: the v1-to-V_delta migration dispatcher, the
-%   universal-rename pass, and per-class migrator functions for the
-%   four 2.0.0-bumped classes.
+%   universal-rename pass, per-class migrator functions for the
+%   four 2.0.0-bumped classes, and the legacy-database readers plus
+%   end-to-end orchestrator that drive the dispatcher off real v1
+%   database files.
 %
 %   Files
+%     fromV1Database   - end-to-end orchestrator. Sniffs the source
+%                        path (file -> sqliteV1 reader, directory ->
+%                        dumbJsonV1 reader), pipes the raw JSON bodies
+%                        through v1_to_v2, writes the successes into a
+%                        fresh did2.database.sqlitedb at the
+%                        destination, and writes any quarantine
+%                        entries to <dst>.quarantine.json. Refuses to
+%                        overwrite existing files unless Overwrite=true.
 %     v1_to_v2         - dispatcher and CLI entry point. Accepts one
 %                        or more did_v1 bodies (struct, struct array,
 %                        cell array, or JSON string) and returns a
@@ -24,5 +34,12 @@
 %                        a function under this namespace by class
 %                        name and calls it with the post-universal
 %                        body.
+%     +readers         - pure-read entry points for the two v1 DID
+%                        storage formats. sqliteV1 reads the legacy
+%                        did.implementations.sqlitedb docs.json_code
+%                        column; dumbJsonV1 walks a
+%                        did.implementations.matlabdumbjsondb tree
+%                        and returns the latest version of every
+%                        Object_id_*_v#####.json file.
 %
 %   See also: docs/v2/PLAN.md §7, §9.6.

--- a/src/did/+did2/+convert/fromV1Database.m
+++ b/src/did/+did2/+convert/fromV1Database.m
@@ -1,0 +1,110 @@
+function result = fromV1Database(srcPath, dstPath, options)
+%FROMV1DATABASE End-to-end did_v1 -> V_delta database migration.
+%
+%   RESULT = did2.convert.fromV1Database(SRCPATH, DSTPATH) reads every
+%   document body out of the v1 source at SRCPATH, runs it through
+%   did2.convert.v1_to_v2, and inserts the successful did2.document
+%   instances into a fresh did2.database.sqlitedb at DSTPATH.
+%
+%   SRCPATH may be either:
+%     - a file (e.g. *.sqlite) - read via did2.convert.readers.sqliteV1
+%       as a did.implementations.sqlitedb file.
+%     - a directory             - read via did2.convert.readers.dumbJsonV1
+%       as a did.implementations.matlabdumbjsondb tree.
+%
+%   Quarantine entries produced by v1_to_v2 are written as a JSON array
+%   to <DSTPATH>.quarantine.json. The function returns the same result
+%   struct v1_to_v2 returns: `migrated`, `quarantine`, `summary`.
+%
+%   Options (name-value):
+%     Validate     (1,1 logical, default true)  - validate each migrated
+%                  document against its V_delta schema.
+%     SchemaCache  (default [])                 - override the shared
+%                  did2.schema.cache singleton (test plumbing).
+%     Verbose      (1,1 logical, default false) - print the v1_to_v2
+%                  end-of-run summary.
+%     Overwrite    (1,1 logical, default false) - refuse to overwrite
+%                  an existing DSTPATH unless true. The quarantine file
+%                  is treated symmetrically.
+%
+%   Errors:
+%     did2:convert:badSourcePath  - SRCPATH is neither a file nor a
+%                                   directory.
+%     did2:convert:overwriteRefused - DSTPATH (or its quarantine
+%                                   sidecar) already exists and
+%                                   Overwrite was not requested.
+%
+%   See also: did2.convert.v1_to_v2,
+%             did2.convert.readers.sqliteV1,
+%             did2.convert.readers.dumbJsonV1,
+%             did2.database.sqlitedb.
+
+arguments
+    srcPath (1,:) char
+    dstPath (1,:) char
+    options.Validate (1,1) logical = true
+    options.SchemaCache = []
+    options.Verbose (1,1) logical = false
+    options.Overwrite (1,1) logical = false
+end
+
+quarantineFile = [dstPath '.quarantine.json'];
+
+if ~options.Overwrite
+    if isfile(dstPath)
+        error('did2:convert:overwriteRefused', ...
+            ['Destination "%s" already exists. Pass Overwrite=true ' ...
+             'to replace it.'], dstPath);
+    end
+    if isfile(quarantineFile)
+        error('did2:convert:overwriteRefused', ...
+            ['Quarantine sidecar "%s" already exists. Pass ' ...
+             'Overwrite=true to replace it.'], quarantineFile);
+    end
+end
+
+if options.Overwrite
+    if isfile(dstPath)
+        delete(dstPath);
+    end
+    if isfile(quarantineFile)
+        delete(quarantineFile);
+    end
+end
+
+if isfile(srcPath)
+    bodies = did2.convert.readers.sqliteV1(srcPath);
+elseif isfolder(srcPath)
+    bodies = did2.convert.readers.dumbJsonV1(srcPath);
+else
+    error('did2:convert:badSourcePath', ...
+        ['Source "%s" is neither a file nor a directory; ' ...
+         'cannot infer reader.'], srcPath);
+end
+
+result = did2.convert.v1_to_v2(bodies, ...
+    'Validate', options.Validate, ...
+    'SchemaCache', options.SchemaCache, ...
+    'Verbose', options.Verbose);
+
+db = did2.database.sqlitedb(dstPath, 'SchemaCache', options.SchemaCache);
+cleanup = onCleanup(@() db.close()); %#ok<NASGU>
+if ~isempty(result.migrated)
+    db.add(result.migrated, 'Validate', options.Validate);
+end
+
+if ~isempty(result.quarantine)
+    writeQuarantineFile(quarantineFile, result.quarantine);
+end
+end
+
+function writeQuarantineFile(quarantineFile, quarantineStructArray)
+text = jsonencode(quarantineStructArray);
+fid = fopen(quarantineFile, 'w');
+if fid < 0
+    error('did2:convert:readerFailed', ...
+        'Failed to open quarantine file "%s" for writing.', quarantineFile);
+end
+cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fwrite(fid, text, 'char');
+end

--- a/tests/+did2/+unittest/testFromV1Database.m
+++ b/tests/+did2/+unittest/testFromV1Database.m
@@ -1,0 +1,228 @@
+function tests = testFromV1Database
+%TESTFROMV1DATABASE End-to-end tests for did2.convert.fromV1Database.
+%
+%   Builds synthetic v1 databases (both flavours) on the fly, runs them
+%   through fromV1Database, and verifies that the resulting v2
+%   did2.database.sqlitedb contains every migrated document. Also
+%   covers the quarantine sidecar and the Overwrite policy.
+%
+%   All tests run with Validate=false so the test runner does not need
+%   a checked-out did-schema directory next to it. The mksqlite gate
+%   lives in setupOnce; if mksqlite is missing the whole file is
+%   skipped, matching testSqliteDb.m.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testFromV1Database');
+
+tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase) %#ok<INUSD>
+if isempty(which('mksqlite'))
+    assumeFail(testCase, ...
+        'mksqlite is not on the MATLAB path; skipping fromV1Database tests.');
+end
+end
+
+function setup(testCase)
+testCase.TestData.tmpDir = makeTempDir();
+testCase.TestData.dstPath = [tempname() '.sqlite'];
+testCase.TestData.srcSqlite = [tempname() '.sqlite'];
+end
+
+function teardown(testCase)
+safeDelete(testCase.TestData.dstPath);
+safeDelete([testCase.TestData.dstPath '.quarantine.json']);
+safeDelete(testCase.TestData.srcSqlite);
+safeRmdir(testCase.TestData.tmpDir);
+end
+
+% ---- sqlite -> v2 ----
+
+function testFromSqliteRoundTripsAllDocs(testCase)
+b1 = jsonencode(makeV1Body('treatment', 'alpha'));
+b2 = jsonencode(makeV1Body('ontology_image', 'beta'));
+b3 = jsonencode(makeV1Body('probe_location', 'gamma'));
+buildV1Sqlite(testCase.TestData.srcSqlite, {b1, b2, b3});
+
+result = did2.convert.fromV1Database( ...
+    testCase.TestData.srcSqlite, ...
+    testCase.TestData.dstPath, ...
+    'Validate', false);
+
+verifyEqual(testCase, result.summary.total, 3);
+verifyEqual(testCase, result.summary.migrated_count, 3);
+verifyEqual(testCase, result.summary.quarantine_count, 0);
+verifyTrue(testCase, isfile(testCase.TestData.dstPath));
+verifyFalse(testCase, isfile([testCase.TestData.dstPath '.quarantine.json']));
+
+db = did2.database.sqlitedb(testCase.TestData.dstPath);
+cleanup = onCleanup(@() db.close()); %#ok<NASGU>
+verifyEqual(testCase, db.count(), 3);
+end
+
+% ---- dumbjsondb -> v2 ----
+
+function testFromDumbJsonRoundTripsAllDocs(testCase)
+b1 = jsonencode(makeV1Body('treatment', 'alpha'));
+b2 = jsonencode(makeV1Body('ontology_image', 'beta'));
+writeDumbJsonDoc(testCase.TestData.tmpDir, 'id_alpha', 0, b1);
+writeDumbJsonDoc(testCase.TestData.tmpDir, 'id_beta',  0, b2);
+
+result = did2.convert.fromV1Database( ...
+    testCase.TestData.tmpDir, ...
+    testCase.TestData.dstPath, ...
+    'Validate', false);
+
+verifyEqual(testCase, result.summary.total, 2);
+verifyEqual(testCase, result.summary.migrated_count, 2);
+verifyEqual(testCase, result.summary.quarantine_count, 0);
+
+db = did2.database.sqlitedb(testCase.TestData.dstPath);
+cleanup = onCleanup(@() db.close()); %#ok<NASGU>
+verifyEqual(testCase, db.count(), 2);
+end
+
+% ---- quarantine ----
+
+function testQuarantineFileWrittenForMalformedDoc(testCase)
+goodBody = jsonencode(makeV1Body('treatment', 'alpha'));
+malformed = 'not json {';
+buildV1Sqlite(testCase.TestData.srcSqlite, {goodBody, malformed});
+
+result = did2.convert.fromV1Database( ...
+    testCase.TestData.srcSqlite, ...
+    testCase.TestData.dstPath, ...
+    'Validate', false);
+
+verifyEqual(testCase, result.summary.total, 2);
+verifyEqual(testCase, result.summary.migrated_count, 1);
+verifyEqual(testCase, result.summary.quarantine_count, 1);
+
+qfile = [testCase.TestData.dstPath '.quarantine.json'];
+verifyTrue(testCase, isfile(qfile));
+text = fileread(qfile);
+decoded = jsondecode(text);
+verifyTrue(testCase, isstruct(decoded));
+% jsondecode of a one-element array collapses to a scalar struct;
+% either way the original_body should round-trip through the field.
+verifyTrue(testCase, isfield(decoded, 'original_body'));
+end
+
+% ---- overwrite policy ----
+
+function testOverwriteFalseRefusesExistingDst(testCase)
+goodBody = jsonencode(makeV1Body('treatment', 'alpha'));
+buildV1Sqlite(testCase.TestData.srcSqlite, {goodBody});
+
+% Touch the destination so it exists before the call.
+fid = fopen(testCase.TestData.dstPath, 'w'); fclose(fid);
+
+verifyError(testCase, @() did2.convert.fromV1Database( ...
+    testCase.TestData.srcSqlite, ...
+    testCase.TestData.dstPath, ...
+    'Validate', false), ...
+    'did2:convert:overwriteRefused');
+end
+
+function testOverwriteTrueReplacesExistingDst(testCase)
+goodBody = jsonencode(makeV1Body('treatment', 'alpha'));
+buildV1Sqlite(testCase.TestData.srcSqlite, {goodBody});
+
+fid = fopen(testCase.TestData.dstPath, 'w');
+fwrite(fid, 'placeholder', 'char');
+fclose(fid);
+
+result = did2.convert.fromV1Database( ...
+    testCase.TestData.srcSqlite, ...
+    testCase.TestData.dstPath, ...
+    'Validate', false, ...
+    'Overwrite', true);
+
+verifyEqual(testCase, result.summary.migrated_count, 1);
+
+db = did2.database.sqlitedb(testCase.TestData.dstPath);
+cleanup = onCleanup(@() db.close()); %#ok<NASGU>
+verifyEqual(testCase, db.count(), 1);
+end
+
+% ---- bad source ----
+
+function testBadSourcePathErrors(testCase)
+verifyError(testCase, @() did2.convert.fromV1Database( ...
+    fullfile(tempdir(), 'no-such-path-zzz'), ...
+    testCase.TestData.dstPath, ...
+    'Validate', false), ...
+    'did2:convert:badSourcePath');
+end
+
+% ---- helpers ----
+
+function body = makeV1Body(className, name)
+body = struct();
+body.document_class = struct( ...
+    'class_name',    className, ...
+    'class_version', '1.0.0', ...
+    'superclasses',  struct( ...
+        'class_name',    'base', ...
+        'class_version', '1.0.0'));
+body.depends_on = struct('name', {}, 'value', {});
+body.base = struct( ...
+    'id',         ['aabb1122ccdd3344_' pad16(name)], ...
+    'session_id', 'aabb1122ccdd3344_9900aabbccddeeff', ...
+    'name',       name, ...
+    'datestamp',  '2024-06-01T12:00:00.000Z');
+body.(className) = struct('marker', name);
+end
+
+function s = pad16(name)
+hex = lower(dec2hex(double(name)));
+joined = strjoin(cellstr(hex(:)'), '');
+joined = [joined repmat('0', 1, 16)];
+s = joined(1:16);
+end
+
+function buildV1Sqlite(tmpFile, bodies)
+dbid = mksqlite(0, 'open', tmpFile);
+cleanup = onCleanup(@() mksqlite(dbid, 'close')); %#ok<NASGU>
+mksqlite(dbid, ['CREATE TABLE docs (' ...
+    'doc_id    TEXT    NOT NULL UNIQUE, ' ...
+    'doc_idx   INTEGER NOT NULL UNIQUE, ' ...
+    'json_code TEXT, ' ...
+    'timestamp NUMERIC, ' ...
+    'PRIMARY KEY(doc_idx AUTOINCREMENT))']);
+for k = 1:numel(bodies)
+    docId = sprintf('id_%04d', k);
+    mksqlite(dbid, ...
+        'INSERT INTO docs (doc_id, doc_idx, json_code, timestamp) VALUES (?, ?, ?, ?)', ...
+        docId, k, bodies{k}, 0);
+end
+end
+
+function writeDumbJsonDoc(dir, docId, version, body)
+filename = sprintf('Object_id_%s_v%s.json', docId, dec2hex(version, 5));
+fullPath = fullfile(dir, filename);
+fid = fopen(fullPath, 'w');
+fwrite(fid, body, 'char');
+fclose(fid);
+try fileattrib(fullPath, '+r'); catch, end
+end
+
+function d = makeTempDir()
+d = tempname();
+mkdir(d);
+end
+
+function safeDelete(p)
+try
+    if isfile(p), delete(p); end
+catch
+end
+end
+
+function safeRmdir(p)
+try
+    if isfolder(p), rmdir(p, 's'); end
+catch
+end
+end

--- a/tests/+did2/+unittest/testReaders.m
+++ b/tests/+did2/+unittest/testReaders.m
@@ -1,0 +1,215 @@
+function tests = testReaders
+%TESTREADERS Unit tests for did2.convert.readers.{sqliteV1, dumbJsonV1}.
+%
+%   Synthesises tiny v1 databases on the fly (a sqlite file built via
+%   mksqlite, and a dumbjsondb-style directory of Object_id_*.json
+%   files) and verifies that the two pure-read readers return the
+%   exact bodies that were written. The sqlite tests are gated by an
+%   assumeFail when mksqlite is missing, matching testSqliteDb.m.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testReaders');
+
+tests = functiontests(localfunctions);
+end
+
+% ---- shared helpers ----
+
+function body = makeV1Body(className, name)
+body = struct();
+body.document_class = struct( ...
+    'class_name',    className, ...
+    'class_version', '1.0.0', ...
+    'superclasses',  struct( ...
+        'class_name',    'base', ...
+        'class_version', '1.0.0'));
+body.depends_on = struct('name', {}, 'value', {});
+body.base = struct( ...
+    'id',         ['aabb1122ccdd3344_' pad16(name)], ...
+    'session_id', 'aabb1122ccdd3344_9900aabbccddeeff', ...
+    'name',       name, ...
+    'datestamp',  '2024-06-01T12:00:00.000Z');
+body.(className) = struct('marker', name);
+end
+
+function s = pad16(name)
+% pad/truncate to 16 hex chars; only used to fabricate unique-looking ids.
+hex = lower(dec2hex(double(name)));
+joined = strjoin(cellstr(hex(:)'), '');
+joined = [joined repmat('0', 1, 16)];
+s = joined(1:16);
+end
+
+function gateMksqlite(testCase)
+if isempty(which('mksqlite'))
+    assumeFail(testCase, ...
+        'mksqlite is not on the MATLAB path; skipping v1 sqlite reader tests.');
+end
+end
+
+% ---- sqliteV1: happy path ----
+
+function testSqliteV1ReturnsAllBodies(testCase)
+gateMksqlite(testCase);
+tmpFile = [tempname() '.sqlite'];
+cleanup = onCleanup(@() safeDelete(tmpFile)); %#ok<NASGU>
+b1 = jsonencode(makeV1Body('treatment', 'alpha'));
+b2 = jsonencode(makeV1Body('ontology_image', 'beta'));
+b3 = jsonencode(makeV1Body('probe_location', 'gamma'));
+buildV1Sqlite(tmpFile, {b1, b2, b3});
+
+bodies = did2.convert.readers.sqliteV1(tmpFile);
+verifyEqual(testCase, numel(bodies), 3);
+verifyEqual(testCase, sort(bodies(:)'), sort({b1, b2, b3}));
+end
+
+function testSqliteV1EmptyDocsTable(testCase)
+gateMksqlite(testCase);
+tmpFile = [tempname() '.sqlite'];
+cleanup = onCleanup(@() safeDelete(tmpFile)); %#ok<NASGU>
+buildV1Sqlite(tmpFile, {});
+
+bodies = did2.convert.readers.sqliteV1(tmpFile);
+verifyTrue(testCase, iscell(bodies));
+verifyEmpty(testCase, bodies);
+end
+
+function testSqliteV1MissingFileErrors(testCase)
+gateMksqlite(testCase);
+verifyError(testCase, ...
+    @() did2.convert.readers.sqliteV1([tempname() '.sqlite']), ...
+    'did2:convert:readerFailed');
+end
+
+function testSqliteV1WrongSchemaErrors(testCase)
+gateMksqlite(testCase);
+tmpFile = [tempname() '.sqlite'];
+cleanup = onCleanup(@() safeDelete(tmpFile)); %#ok<NASGU>
+dbid = mksqlite(0, 'open', tmpFile);
+mksqlite(dbid, 'CREATE TABLE other(x INTEGER)');
+mksqlite(dbid, 'close');
+verifyError(testCase, ...
+    @() did2.convert.readers.sqliteV1(tmpFile), ...
+    'did2:convert:readerFailed');
+end
+
+% ---- dumbJsonV1: happy path ----
+
+function testDumbJsonV1ReturnsAllBodies(testCase)
+tmpDir = makeTempDir();
+cleanup = onCleanup(@() safeRmdir(tmpDir)); %#ok<NASGU>
+b1 = jsonencode(makeV1Body('treatment', 'alpha'));
+b2 = jsonencode(makeV1Body('ontology_image', 'beta'));
+b3 = jsonencode(makeV1Body('probe_location', 'gamma'));
+writeDumbJsonDoc(tmpDir, 'id_alpha', 0, b1);
+writeDumbJsonDoc(tmpDir, 'id_beta',  0, b2);
+writeDumbJsonDoc(tmpDir, 'id_gamma', 0, b3);
+
+bodies = did2.convert.readers.dumbJsonV1(tmpDir);
+verifyEqual(testCase, numel(bodies), 3);
+verifyEqual(testCase, sort(bodies(:)'), sort({b1, b2, b3}));
+end
+
+function testDumbJsonV1ReturnsLatestVersion(testCase)
+tmpDir = makeTempDir();
+cleanup = onCleanup(@() safeRmdir(tmpDir)); %#ok<NASGU>
+oldBody = jsonencode(makeV1Body('treatment', 'old'));
+newBody = jsonencode(makeV1Body('treatment', 'new'));
+writeDumbJsonDoc(tmpDir, 'id_versioned', 0, oldBody);
+writeDumbJsonDoc(tmpDir, 'id_versioned', 5, newBody);
+
+bodies = did2.convert.readers.dumbJsonV1(tmpDir);
+verifyEqual(testCase, numel(bodies), 1);
+verifyEqual(testCase, bodies{1}, newBody);
+end
+
+function testDumbJsonV1FindsNestedDirname(testCase)
+tmpDir = makeTempDir();
+cleanup = onCleanup(@() safeRmdir(tmpDir)); %#ok<NASGU>
+inner = fullfile(tmpDir, '.dumbjsondb');
+mkdir(inner);
+body = jsonencode(makeV1Body('treatment', 'nested'));
+writeDumbJsonDoc(inner, 'id_nested', 0, body);
+
+bodies = did2.convert.readers.dumbJsonV1(tmpDir);
+verifyEqual(testCase, numel(bodies), 1);
+verifyEqual(testCase, bodies{1}, body);
+end
+
+function testDumbJsonV1EmptyDirectory(testCase)
+tmpDir = makeTempDir();
+cleanup = onCleanup(@() safeRmdir(tmpDir)); %#ok<NASGU>
+bodies = did2.convert.readers.dumbJsonV1(tmpDir);
+verifyTrue(testCase, iscell(bodies));
+verifyEmpty(testCase, bodies);
+end
+
+function testDumbJsonV1MissingDirectoryErrors(testCase)
+verifyError(testCase, ...
+    @() did2.convert.readers.dumbJsonV1(fullfile(tempdir(), 'no-such-dir-xyz')), ...
+    'did2:convert:readerFailed');
+end
+
+function testDumbJsonV1MalformedFileIsRawBytes(testCase)
+% A malformed (non-JSON) file should still be returned verbatim; the
+% reader is pure-read and does not parse. Downstream v1_to_v2 routes
+% the parse failure into quarantine.
+tmpDir = makeTempDir();
+cleanup = onCleanup(@() safeRmdir(tmpDir)); %#ok<NASGU>
+malformed = 'not json {';
+writeDumbJsonDoc(tmpDir, 'id_bad', 0, malformed);
+
+bodies = did2.convert.readers.dumbJsonV1(tmpDir);
+verifyEqual(testCase, numel(bodies), 1);
+verifyEqual(testCase, bodies{1}, malformed);
+end
+
+% ---- low-level fixture builders ----
+
+function buildV1Sqlite(tmpFile, bodies)
+% Replicate the minimal subset of did.implementations.sqlitedb's
+% create_db_tables() that the v1 reader cares about.
+dbid = mksqlite(0, 'open', tmpFile);
+cleanup = onCleanup(@() mksqlite(dbid, 'close')); %#ok<NASGU>
+mksqlite(dbid, ['CREATE TABLE docs (' ...
+    'doc_id    TEXT    NOT NULL UNIQUE, ' ...
+    'doc_idx   INTEGER NOT NULL UNIQUE, ' ...
+    'json_code TEXT, ' ...
+    'timestamp NUMERIC, ' ...
+    'PRIMARY KEY(doc_idx AUTOINCREMENT))']);
+for k = 1:numel(bodies)
+    docId = sprintf('id_%04d', k);
+    mksqlite(dbid, ...
+        'INSERT INTO docs (doc_id, doc_idx, json_code, timestamp) VALUES (?, ?, ?, ?)', ...
+        docId, k, bodies{k}, 0);
+end
+end
+
+function writeDumbJsonDoc(dir, docId, version, body)
+filename = sprintf('Object_id_%s_v%s.json', docId, dec2hex(version, 5));
+fullPath = fullfile(dir, filename);
+fid = fopen(fullPath, 'w');
+fwrite(fid, body, 'char');
+fclose(fid);
+% Ensure readable just like did.file.dumbjsondb expects.
+try fileattrib(fullPath, '+r'); catch, end
+end
+
+function d = makeTempDir()
+d = tempname();
+mkdir(d);
+end
+
+function safeDelete(p)
+try
+    if isfile(p), delete(p); end
+catch
+end
+end
+
+function safeRmdir(p)
+try
+    if isfolder(p), rmdir(p, 's'); end
+catch
+end
+end


### PR DESCRIPTION
## Summary

Adds the input side of the v1 → V_delta converter: two readers that pull document JSON bodies out of legacy v1 DID databases (sqlite and matlabdumbjsondb flavours), plus an end-to-end orchestrator (`fromV1Database`) that takes a v1 DB path, pipes every document through `did2.convert.v1_to_v2` (landed in PR #126), and writes the migrated docs into a fresh v2 sqlitedb. This is the "tool that opens an NDI dataset or session, grabs all the documents in JSON, and runs the conversion tool" line of work that surfaced in design discussion after PR #126 merged.

The NDI-layer wrapper (`ndi.convert.session(S, dstPath)` or similar) is deliberately kept out of `+did2` and left for NDI-matlab, so `+did2` stays NDI-agnostic.

## What landed

### New `+did2/+convert/+readers/` subpackage

- **`sqliteV1.m`** — reader for `did.implementations.sqlitedb` files. Opens the `.sqlite` via mksqlite (the same MEX `+did2`'s storage already requires), runs `SELECT json_code FROM docs`, returns the bodies as a cellstr. The v1 schema was discovered by reading `src/did/+did/+implementations/sqlitedb.m`:
  - documents table: `docs(doc_id TEXT UNIQUE, doc_idx INTEGER AUTOINCREMENT PK, timestamp NUMERIC, json_code TEXT)`
  - other v1 tables (`branches`, `branch_docs`, `doc_data`, `fields`, `files`) are out of scope at this layer; the reader is body-level only.
  - errors flow through `did2:convert:readerFailed` (file missing, table missing, mksqlite missing).
- **`dumbJsonV1.m`** — reader for `matlabdumbjsondb` directories. Walks `<dbdir>/{.dumbjsondb,dumbjsondb}/` for `Object_id_<ID>_v<HEX5>.json` body files and picks the highest-version body per id (matching `latestdocversion` semantics). Per-doc file pattern was discovered by reading `src/did/+did/+implementations/matlabdumbjsondb.m` + `src/did/+did/+file/dumbjsondb.m`:
  - `Object_id_<ID>_v<HEX5>.json` — document JSON body (`HEX5 = dec2hex(version, 5)`).
  - `Object_id_<ID>.txt` — meta file pointing at the latest version.
  - `Object_id_<ID>_v<HEX5>.json.binary` — associated binary file (out of scope here).
- **`Contents.m`** — package overview.

### New `+did2/+convert/fromV1Database.m`

End-to-end orchestrator. Sniffs `srcPath`:
- file path → `sqliteV1` reader,
- directory → `dumbJsonV1` reader,
- anything else → `did2:convert:badSourcePath`.

Pipes the bodies through `did2.convert.v1_to_v2`, inserts the successful `did2.document` instances into a fresh `did2.database.sqlitedb` at `dstPath`, and writes the quarantine struct array (if any) to `<dstPath>.quarantine.json` via `jsonencode`. Refuses to overwrite an existing `dstPath` unless `Overwrite=true` is passed. Returns the same `{migrated, quarantine, summary}` struct that `v1_to_v2` returns.

Name-value options: `Validate` (default true), `SchemaCache` (default `[]`), `Verbose` (default false), `Overwrite` (default false).

### Tests

- **`tests/+did2/+unittest/testReaders.m`** — synthesises tiny v1 databases in tempfiles for both flavours and asserts the readers return the expected bodies. Covers empty databases, empty directories, the highest-version-wins rule for the dumbjsondb reader, and the malformed-source error paths. Gated via `assumeFail` when mksqlite is not on the MATLAB path (matches the existing `testSqliteDb` pattern).
- **`tests/+did2/+unittest/testFromV1Database.m`** — end-to-end tests through the orchestrator. Builds a synthetic v1 sqlite source, runs `fromV1Database` to a tempfile v2 sqlite, verifies every doc round-trips and `summary.migrated_count` matches; same for a dumbjsondb source; verifies quarantine on a malformed input lands in `<dstPath>.quarantine.json`; verifies `Overwrite=false` (default) refuses an existing dst and `Overwrite=true` proceeds. Tests use `'Validate', false` so they do not depend on a checked-out did-schema directory.

### Doc updates

- `src/did/+did2/+convert/Contents.m` — documents the new `+readers` subpackage and the `fromV1Database` entry.
- `docs/v2/PLAN.md` — progress log entry describing this PR.

## Deliberate out-of-scope: files

V1 DID documents whose body contains a populated `files.file_info` array reference binary blobs that live in the v1 database's `<dbdir>/files/<uid>` cache (sqlitedb) or in `Object_id_<ID>_v<HEX5>.json.binary` sidecars (dumbjsondb). The readers in this PR ignore those blobs entirely — they only return the body JSON. A future pass needs to (a) copy the file blobs into a v2 file store and (b) ensure migrators preserve the `files` block in the body so v2 docs can resolve their attachments. In practice this affects image-flavoured / raw-data classes (`ontology_image` and NDI subclasses like `epoch`, `element`).

## Test plan

- [ ] `runtests('did2.unittest.testReaders')` — passes (mksqlite-gated subset auto-skips if mksqlite absent).
- [ ] `runtests('did2.unittest.testFromV1Database')` — passes (mksqlite-gated subset auto-skips if mksqlite absent).
- [ ] `runtests('did2.unittest')` — full bucket stays green (no regressions in testDocumentScaffold, testQuery, testSchemaCache, testCompileQuery, testSqliteDb, testConvertV1ToV2, testMigrators).
- [ ] Sanity-check `fromV1Database` end-to-end on a real NDI v1 sqlite if one is at hand: zero quarantine on the small test dataset, expected `summary.by_class` totals.

Tests were not run locally (no MATLAB in the authoring environment); CI / a local MATLAB pass will verify.

## What remains in step 6

- **6d** (CI test data pipeline): With the readers in place, 6d can wire a real ~16 MB v1 NDI sqlite into the per-PR `integration-small` job and feed it through `fromV1Database` end-to-end. Still needs decisions on dataset hosting and mksqlite availability in the CI runner.
- **Files migration** (the out-of-scope flag above): copy the `<dbdir>/files/` blob cache into a v2 file store and have migrators preserve the body's `files` block.
- **NDI session wrapper**: a thin `ndi.convert.session(S, dstPath)` shim that calls `fromV1Database` on the session's DB path — lives in NDI-matlab, not here.
- **6e** (NDIcalc-vis-matlab migrators): gated on real test datasets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmK42oJBBgqKFrx6r1wQc6)_