### PR TITLE
v2 step 6e: ngrid superclass migrator

### DIFF
--- a/src/did/+did2/+convert/+migrators/Contents.m
+++ b/src/did/+did2/+convert/+migrators/Contents.m
@@ -43,6 +43,12 @@
 %                           already snake_case in v1, no rename
 %                           needed. Accepts the older `clocktype`
 %                           spelling defensively.
+%     ngrid               - SUPERCLASS migrator; rename data_dim ->
+%                           dim_sizes and derive ndims = numel(data_dim).
+%                           Drops v1-only data_size and coordinates.
+%                           Applied to any document that lists ngrid
+%                           in its superclass chain (e.g., hartley_calc
+%                           via reverse_correlation).
 %
 %   Calculator-base wrappers (PLAN.md §9.6 sub-step 6d, 20211116-driven):
 %   each calls did2.convert.calcCommon to move v1's

--- a/src/did/+did2/+convert/+migrators/ngrid.m
+++ b/src/did/+did2/+convert/+migrators/ngrid.m
@@ -1,0 +1,58 @@
+function v2Body = ngrid(preBody)
+%NGRID Migrate a did_v1 ngrid block to V_delta.
+%
+%   This is a *superclass migrator*: ngrid is rarely a concrete
+%   class; it ships as a superclass-contributed property block on
+%   classes like hartley_calc (via reverse_correlation -> ngrid).
+%   The dispatcher walks document_class.superclasses (as
+%   normalised by universalRenames) and runs this migrator on any
+%   document that declares ngrid among its superclasses, before
+%   the concrete-class migrator runs.
+%
+%   Field renames / structural derivations inside the ngrid
+%   property block:
+%       ngrid.data_dim  -> ngrid.dim_sizes
+%       (none)          -> ngrid.ndims = numel(data_dim)
+%
+%   v1 also stores `data_size` (per-element byte size) and
+%   `coordinates` (sample coordinates along each dimension); both
+%   are v1-only fields with no V_delta counterpart on ngrid and
+%   are dropped per the conversion default (PLAN.md §9.6 Q1:
+%   surface drop-counts in summary; promote to per-class migrators
+%   only if a consumer surfaces).
+%
+%   v1 `data_type` matches V_delta `data_type` verbatim and passes
+%   through. If v1 already supplied `ndims` (rare), the value is
+%   preserved instead of recomputed.
+
+arguments
+    preBody (1,1) struct
+end
+
+v2Body = preBody;
+if ~isfield(v2Body, 'ngrid') || ~isstruct(v2Body.ngrid)
+    return;
+end
+
+block = v2Body.ngrid;
+
+if isfield(block, 'data_dim')
+    dimSizes = block.data_dim;
+    block.dim_sizes = dimSizes;
+    block = rmfield(block, 'data_dim');
+    if ~isfield(block, 'ndims')
+        block.ndims = double(numel(dimSizes));
+    end
+elseif isfield(block, 'dim_sizes') && ~isfield(block, 'ndims')
+    block.ndims = double(numel(block.dim_sizes));
+end
+
+if isfield(block, 'data_size')
+    block = rmfield(block, 'data_size');
+end
+if isfield(block, 'coordinates')
+    block = rmfield(block, 'coordinates');
+end
+
+v2Body.ngrid = block;
+end

--- a/tests/+did2/+unittest/testMigrators.m
+++ b/tests/+did2/+unittest/testMigrators.m
@@ -411,3 +411,62 @@ doc = result.migrated{1};
 verifyEqual(testCase, doc.get('element_epoch.t0'), 0);
 verifyEqual(testCase, doc.get('element_epoch.t1'), 42);
 end
+
+% --- ngrid superclass migrator (20211116 corpus: 210 hartley_calc) ---
+
+function testNgridDerivesNdimsFromDataDim(testCase)
+v1 = wrap('hartley_calc', 'ngrid', struct( ...
+    'data_size',   8, ...
+    'data_type',   'double', ...
+    'data_dim',    [200 200 36 2], ...
+    'coordinates', [0 1 2 3]));
+out = did2.convert.migrators.ngrid(did2.convert.universalRenames(v1));
+verifyEqual(testCase, out.ngrid.ndims, 4);
+verifyEqual(testCase, out.ngrid.dim_sizes, [200 200 36 2]);
+verifyEqual(testCase, out.ngrid.data_type, 'double');
+verifyFalse(testCase, isfield(out.ngrid, 'data_dim'));
+verifyFalse(testCase, isfield(out.ngrid, 'data_size'));
+verifyFalse(testCase, isfield(out.ngrid, 'coordinates'));
+end
+
+function testNgridPreservesExplicitNdims(testCase)
+v1 = wrap('hartley_calc', 'ngrid', struct( ...
+    'ndims',    7, ...
+    'data_dim', [10 10]));
+out = did2.convert.migrators.ngrid(did2.convert.universalRenames(v1));
+% Even though numel(data_dim) is 2, the migrator preserves an
+% explicit v1 ndims rather than overwriting it. (If consumers ever
+% surface a conflict between the two, we can promote to an error.)
+verifyEqual(testCase, out.ngrid.ndims, 7);
+verifyEqual(testCase, out.ngrid.dim_sizes, [10 10]);
+end
+
+function testNgridNoOpWhenBlockAbsent(testCase)
+v1 = wrap('hartley_calc', 'hartley_calc', struct('input_parameters', []));
+out = did2.convert.migrators.ngrid(did2.convert.universalRenames(v1));
+verifyFalse(testCase, isfield(out, 'ngrid'));
+end
+
+function testNgridDerivesFromExistingDimSizes(testCase)
+v1 = wrap('hartley_calc', 'ngrid', struct('dim_sizes', [5 5 5]));
+out = did2.convert.migrators.ngrid(did2.convert.universalRenames(v1));
+verifyEqual(testCase, out.ngrid.ndims, 3);
+end
+
+function testEndToEndDispatcherForHartleyCalc(testCase)
+% End-to-end: hartley_calc body with v1-shaped ngrid block migrates
+% through the calc helper, the ngrid superclass migrator, and the
+% dispatcher's chain-padding step without quarantine.
+v1 = wrap('hartley_calc', 'hartley_calc', struct('input_parameters', []));
+v1.ngrid = struct( ...
+    'data_size', 8, ...
+    'data_type', 'double', ...
+    'data_dim',  [200 200 36 2]);
+v1.document_class.superclasses = struct('class_name', ...
+    {'base', 'hartley_reverse_correlation', 'ngrid'});
+result = did2.convert.v1_to_v2(v1, 'Validate', false);
+verifyEqual(testCase, result.summary.migrated_count, 1);
+doc = result.migrated{1};
+verifyEqual(testCase, doc.get('ngrid.ndims'), 4);
+verifyEqual(testCase, doc.get('ngrid.dim_sizes'), [200 200 36 2]);
+end


### PR DESCRIPTION
Single migrator on top of merged #128. Clears the residual 210-quarantine `hartley_calc` cluster on the 20211116 discovery corpus.

## Summary

- Adds `+migrators/ngrid.m`, a **superclass migrator** (dispatcher walks `document_class.superclasses`, runs `+migrators/<name>.m` for each match before the concrete-class migrator runs).
- Triggered on every doc whose superclass chain includes `ngrid` — concretely, `hartley_calc` reaches it via `hartley_reverse_correlation → reverse_correlation → ngrid`.
- Transformations:
  - `ngrid.data_dim` → `ngrid.dim_sizes` (V_delta rename)
  - derives `ngrid.ndims = numel(data_dim)` (V_delta `ndims` is required; v1 carries it implicitly as the length of `data_dim`)
  - drops v1-only `ngrid.data_size` and `ngrid.coordinates`
  - `ngrid.data_type` passes through unchanged
- Preserves an explicit v1 `ndims` rather than overwriting it (rare, but a cheap defense).

## Tests

`testMigrators` gains:
- `testNgridDerivesNdimsFromDataDim` — corpus shape (`data_dim: [200 200 36 2]` → `ndims=4`, `dim_sizes=[200 200 36 2]`, drops `data_size`/`coordinates`).
- `testNgridPreservesExplicitNdims` — explicit v1 `ndims` wins over derivation.
- `testNgridNoOpWhenBlockAbsent` — clean no-op when ngrid block missing.
- `testNgridDerivesFromExistingDimSizes` — derivation also works from `dim_sizes` when v1 already used the V_delta name.
- `testEndToEndDispatcherForHartleyCalc` — full v1 `hartley_calc` body migrates through the calc helper, ngrid superclass migrator, dispatcher chain-padding, all without quarantine.

## Projection

| corpus | total | migrated | quarantined |
|---|---|---|---|
| PRED | 14 | 14 | 0 |
| 20211116 | 1220 | **1220** | **0** |

Both corpora now round-trip clean. No further migrator work needed for the current discovery set.

## Out of scope (still pending follow-ups from #128)

- `did2.validate.references` for `depends_on` referential integrity at DB-ingest time (you noted you'd track this).
- Step 6e proper (NDIcalc-vis migrators beyond the calc base) once a corpus reaches further.


---
_Generated by [Claude Code](https://claude.ai/code/session_011wtV7T1TKrxbGBeW71ebQn)_