### PR TITLE
v2 follow-ups: did2.validate.references + B/Dab/JH/Soph discovery corpora

### DIFF
--- a/src/did/+did2/+convert/v1_to_v2.m
+++ b/src/did/+did2/+convert/v1_to_v2.m
@@ -33,13 +33,25 @@ function result = v1_to_v2(v1Bodies, options)
 %                  the post-universal class name to its migrated count.
 %
 %   Options (name-value):
-%     Validate     (1,1 logical, default true) - validate each migrated
-%                  document via did2.schema.cache.validateDocument.
-%                  Validation failures route to quarantine.
-%     SchemaCache  ([] or a did2.schema.cache handle, default []) -
-%                  override the shared schema cache. Used by tests.
-%     Verbose      (1,1 logical, default false) - print the end-of-run
-%                  summary report to stdout.
+%     Validate         (1,1 logical, default true) - validate each
+%                      migrated document via
+%                      did2.schema.cache.validateDocument. Validation
+%                      failures route to quarantine.
+%     SchemaCache      ([] or a did2.schema.cache handle, default []) -
+%                      override the shared schema cache. Used by tests.
+%     Verbose          (1,1 logical, default false) - print the
+%                      end-of-run summary report to stdout.
+%     CheckReferences  (1,1 logical, default false) - after the per-doc
+%                      pipeline finishes, run did2.validate.references
+%                      against the migrated batch. The result lands
+%                      under result.references. Orphan edges are NOT
+%                      routed to quarantine; the report lets callers
+%                      decide how to react.
+%     ReferenceDatabase (did2.database.sqlitedb or [], default []) -
+%                      if supplied, references-check accepts edges
+%                      that resolve to documents already stored in
+%                      this DB (e.g. when ingesting an incremental
+%                      batch on top of a populated database).
 %
 %   See also: did2.convert.universalRenames, did2.convert.migrators,
 %   docs/v2/PLAN.md §9.6.
@@ -49,6 +61,8 @@ arguments
     options.Validate (1,1) logical = true
     options.SchemaCache = []
     options.Verbose (1,1) logical = false
+    options.CheckReferences (1,1) logical = false
+    options.ReferenceDatabase = []
 end
 
 bodies = normaliseInput(v1Bodies);
@@ -99,6 +113,15 @@ result.summary = struct( ...
     'migrated_count',   numel(migrated), ...
     'quarantine_count', numel(quarantine), ...
     'by_class',         buildByClassTable(classCountNames, classCountValues));
+
+if options.CheckReferences
+    if ~isempty(options.ReferenceDatabase)
+        result.references = did2.validate.references(migrated, ...
+            'Database', options.ReferenceDatabase);
+    else
+        result.references = did2.validate.references(migrated);
+    end
+end
 
 if options.Verbose
     printSummary(result);

--- a/src/did/+did2/+validate/references.m
+++ b/src/did/+did2/+validate/references.m
@@ -1,0 +1,182 @@
+function report = references(docs, opts)
+%REFERENCES Validate did2 document `depends_on` referential integrity.
+%
+%   REPORT = did2.validate.references(DOCS) checks that every
+%   non-empty `depends_on[i].value` on every document in DOCS
+%   resolves to the id of another document in DOCS. Edges whose
+%   value is empty (the schema's `mustBeNonEmpty=false` case) are
+%   skipped — they represent intentionally unfilled optional
+%   dependencies.
+%
+%   REPORT = did2.validate.references(DOCS, 'Database', DB) also
+%   accepts edges that resolve to documents already stored in DB
+%   (a `did2.database.sqlitedb` instance). Use this when validating
+%   an incremental import batch against a populated database.
+%
+%   REPORT = did2.validate.references(..., 'KnownIds', IDS) lets
+%   the caller pass a cell array of additional `did_uid` strings
+%   that should be treated as resolvable (e.g., IDs from a prior
+%   batch that has not yet been committed).
+%
+%   REPORT is a struct with fields:
+%       total_docs       - number of documents inspected
+%       edges_examined   - number of non-empty depends_on edges
+%       orphans          - struct array (one entry per dangling
+%                          edge) with fields:
+%                              doc_id     - id of the source document
+%                              doc_class  - className() of the source
+%                              edge_name  - depends_on[i].name
+%                              edge_value - the unresolved id string
+%       orphan_count     - numel(orphans)
+%
+%   The function does not throw on orphan edges — it returns a
+%   report so callers can decide how to react (quarantine the batch,
+%   log + continue, etc).
+%
+%   Example
+%   -------
+%       result = did2.convert.v1_to_v2(v1Docs);
+%       refReport = did2.validate.references(result.migrated);
+%       if refReport.orphan_count > 0
+%           error('Migration would create %d orphan depends_on edges.', ...
+%               refReport.orphan_count);
+%       end
+%
+%   See also: did2.document, did2.database.sqlitedb,
+%             did2.convert.v1_to_v2.
+
+arguments
+    docs
+    opts.Database = []
+    opts.KnownIds (1,:) cell = {}
+end
+
+list = normaliseDocList(docs);
+
+knownIds = struct();
+for k = 1:numel(list)
+    id = docId(list{k});
+    if ~isempty(id)
+        knownIds.(idKey(id)) = true;
+    end
+end
+for k = 1:numel(opts.KnownIds)
+    extra = char(opts.KnownIds{k});
+    if ~isempty(extra)
+        knownIds.(idKey(extra)) = true;
+    end
+end
+
+useDb = ~isempty(opts.Database);
+if useDb
+    dbIds = opts.Database.allIds();
+    for k = 1:numel(dbIds)
+        knownIds.(idKey(dbIds{k})) = true;
+    end
+end
+
+orphans = struct('doc_id', {}, 'doc_class', {}, ...
+    'edge_name', {}, 'edge_value', {});
+edgesExamined = 0;
+for k = 1:numel(list)
+    doc = list{k};
+    deps = dependsOnEntries(doc);
+    sourceId = docId(doc);
+    sourceClass = docClass(doc);
+    for j = 1:numel(deps)
+        value = char(deps{j}.value);
+        if isempty(value)
+            continue;
+        end
+        edgesExamined = edgesExamined + 1;
+        if isfield(knownIds, idKey(value))
+            continue;
+        end
+        orphans(end+1) = struct( ...
+            'doc_id',     sourceId, ...
+            'doc_class',  sourceClass, ...
+            'edge_name',  char(deps{j}.name), ...
+            'edge_value', value); %#ok<AGROW>
+    end
+end
+
+report = struct( ...
+    'total_docs',     numel(list), ...
+    'edges_examined', edgesExamined, ...
+    'orphans',        orphans, ...
+    'orphan_count',   numel(orphans));
+end
+
+function list = normaliseDocList(docOrList)
+if isa(docOrList, 'did2.document')
+    list = num2cell(docOrList(:));
+    return;
+end
+if iscell(docOrList)
+    list = docOrList(:);
+    return;
+end
+if isstruct(docOrList)
+    list = num2cell(docOrList(:));
+    return;
+end
+error('did2:validate:invalidInput', ...
+    'docs must be a did2.document array, cell array, or struct array.');
+end
+
+function id = docId(doc)
+if isa(doc, 'did2.document')
+    id = char(doc.get('base.id'));
+elseif isstruct(doc) && isfield(doc, 'base') && isfield(doc.base, 'id')
+    id = char(doc.base.id);
+else
+    id = '';
+end
+end
+
+function cls = docClass(doc)
+if isa(doc, 'did2.document')
+    cls = doc.className();
+elseif isstruct(doc) && isfield(doc, 'document_class') ...
+        && isfield(doc.document_class, 'class_name')
+    cls = char(doc.document_class.class_name);
+else
+    cls = '';
+end
+end
+
+function entries = dependsOnEntries(doc)
+entries = {};
+if isa(doc, 'did2.document')
+    s = doc.toStruct();
+elseif isstruct(doc)
+    s = doc;
+else
+    return;
+end
+if ~isfield(s, 'depends_on') || isempty(s.depends_on)
+    return;
+end
+d = s.depends_on;
+for k = 1:numel(d)
+    if isstruct(d)
+        e = d(k);
+    elseif iscell(d)
+        e = d{k};
+    else
+        continue;
+    end
+    if ~isstruct(e) || ~isfield(e, 'name') || ~isfield(e, 'value')
+        continue;
+    end
+    entries{end+1} = struct( ...
+        'name',  char(e.name), ...
+        'value', char(e.value)); %#ok<AGROW>
+end
+end
+
+function key = idKey(id)
+% Did uids are 16-hex_16-hex; struct fieldnames can't start with
+% a digit. Prefix with 'k_' so any did_uid becomes a valid key.
+key = ['k_', id];
+end

--- a/tests/+did2/+unittest/+helpers/ensureCorpus.m
+++ b/tests/+did2/+unittest/+helpers/ensureCorpus.m
@@ -1,0 +1,28 @@
+function corpusDir = ensureCorpus(corpusURL, cacheName, innerDir)
+%ENSURECORPUS Download (if necessary) and extract a corpus zip.
+%
+%   CORPUSDIR = did2.unittest.helpers.ensureCorpus(URL, CACHENAME, INNERDIR)
+%   returns <tempdir>/<CACHENAME>/<INNERDIR>, fetching and unzipping
+%   URL into the cache on first call so repeated runs in the same
+%   MATLAB session reuse the same files.
+
+arguments
+    corpusURL (1,:) char
+    cacheName (1,:) char
+    innerDir  (1,:) char
+end
+
+cacheRoot = fullfile(tempdir(), cacheName);
+corpusDir = fullfile(cacheRoot, innerDir);
+if isfolder(corpusDir) && ~isempty(dir(fullfile(corpusDir, '*.json')))
+    return;
+end
+if ~exist(cacheRoot, 'dir')
+    mkdir(cacheRoot);
+end
+zipPath = fullfile(cacheRoot, [innerDir '.zip']);
+if ~isfile(zipPath)
+    websave(zipPath, corpusURL);
+end
+unzip(zipPath, cacheRoot);
+end

--- a/tests/+did2/+unittest/+helpers/installSchemaPath.m
+++ b/tests/+did2/+unittest/+helpers/installSchemaPath.m
@@ -1,0 +1,56 @@
+function installSchemaPath(testCase, skipMessageContext)
+%INSTALLSCHEMAPATH Probe a V_delta schema dir, set DID_SCHEMA_PATH, reset cache.
+%
+%   did2.unittest.helpers.installSchemaPath(TESTCASE, SKIPMESSAGECONTEXT) probes
+%   DID_SCHEMA_PATH then the sibling-checkout default. If neither
+%   resolves to a folder of V_delta `*.json` files, the test is
+%   filtered via assumeFail with a clear message. Otherwise the env
+%   var is set and the schema-cache singleton is reset.
+%
+%   Seeds testCase.TestData.previousSchemaPath /
+%   .didOverrideSchemaPath so did2.unittest.helpers.restoreSchemaPath can run
+%   safely in teardownOnce even when this helper aborted via
+%   assumeFail.
+
+arguments
+    testCase
+    skipMessageContext (1,:) char = 'skipping corpus test'
+end
+
+if ~isfield(testCase.TestData, 'previousSchemaPath')
+    testCase.TestData.previousSchemaPath = getenv('DID_SCHEMA_PATH');
+end
+if ~isfield(testCase.TestData, 'didOverrideSchemaPath')
+    testCase.TestData.didOverrideSchemaPath = false;
+end
+
+schemaPath = resolveSchemaPath();
+if isempty(schemaPath)
+    assumeFail(testCase, ...
+        ['V_delta schemas not found. Set DID_SCHEMA_PATH or check out ', ...
+         'did-schema as a sibling of DID-matlab; ' skipMessageContext '.']);
+end
+setenv('DID_SCHEMA_PATH', schemaPath);
+testCase.TestData.didOverrideSchemaPath = true;
+did2.schema.cache.resetSingleton();
+end
+
+function p = resolveSchemaPath()
+candidates = {};
+envPath = getenv('DID_SCHEMA_PATH');
+if ~isempty(envPath)
+    candidates{end+1} = envPath; %#ok<AGROW>
+end
+toolboxDir = did.toolboxdir();
+candidates{end+1} = fullfile(toolboxDir, '..', '..', '..', ...
+    'did-schema', 'schemas', 'V_delta', 'stable'); %#ok<AGROW>
+
+p = '';
+for k = 1:numel(candidates)
+    candidate = candidates{k};
+    if isfolder(candidate) && ~isempty(dir(fullfile(candidate, '*.json')))
+        p = candidate;
+        return;
+    end
+end
+end

--- a/tests/+did2/+unittest/+helpers/restoreSchemaPath.m
+++ b/tests/+did2/+unittest/+helpers/restoreSchemaPath.m
@@ -1,0 +1,14 @@
+function restoreSchemaPath(testCase)
+%RESTORESCHEMAPATH Restore DID_SCHEMA_PATH captured by installSchemaPath.
+%
+%   Safe to call from teardownOnce even when installSchemaPath
+%   filtered the suite before the override happened: the absence of
+%   the .didOverrideSchemaPath flag (or its `false` value) makes
+%   this a no-op.
+
+if isfield(testCase.TestData, 'didOverrideSchemaPath') ...
+        && testCase.TestData.didOverrideSchemaPath
+    setenv('DID_SCHEMA_PATH', testCase.TestData.previousSchemaPath);
+    did2.schema.cache.resetSingleton();
+end
+end

--- a/tests/+did2/+unittest/+helpers/runCorpusDiscovery.m
+++ b/tests/+did2/+unittest/+helpers/runCorpusDiscovery.m
@@ -1,0 +1,60 @@
+function corpusDir = runCorpusDiscovery(testCase, corpusName, corpusURL, innerDir)
+%RUNCORPUSDISCOVERY Shared driver for v1 corpus discovery-mode tests.
+%
+%   CORPUSDIR = did2.unittest.helpers.runCorpusDiscovery(TESTCASE, CORPUSNAME,
+%       CORPUSURL, INNERDIR) is the body of each per-corpus discovery
+%   test. It handles the schema-path probe + override, downloads and
+%   caches the corpus zip, runs every contained v1 document through
+%   did2.convert.v1_to_v2 with Validate=true, writes the per-run
+%   summary JSON under corpus-reports/<CORPUSNAME>-summary.json, and
+%   prints a stdout summary that the CI log captures.
+%
+%   The test that calls this function is responsible for any
+%   pre-call gating (e.g., env-var guards), and for the schema-path
+%   teardown via did2.unittest.helpers.restoreSchemaPath.
+%
+%   Returns the corpus directory it walked, so callers can layer
+%   extra assertions on top if they want.
+%
+%   This is **discovery mode**: nothing is asserted about the
+%   migrated_count / quarantine_count split; the report is the
+%   deliverable.
+
+arguments
+    testCase
+    corpusName (1,:) char
+    corpusURL  (1,:) char
+    innerDir   (1,:) char
+end
+
+did2.unittest.helpers.installSchemaPath(testCase, sprintf('skipping %s corpus test', corpusName));
+
+cacheName = ['did2-corpus-' innerDir];
+corpusDir = did2.unittest.helpers.ensureCorpus(corpusURL, cacheName, innerDir);
+
+files = dir(fullfile(corpusDir, '*.json'));
+files = files(~startsWith({files.name}, '._'));
+verifyGreaterThan(testCase, numel(files), 0, ...
+    sprintf('No JSON files found under %s', corpusDir));
+
+bodies = cell(numel(files), 1);
+for k = 1:numel(files)
+    bodies{k} = fileread(fullfile(files(k).folder, files(k).name));
+end
+
+result = did2.convert.v1_to_v2(bodies, 'Validate', true);
+
+reasons = did2.unittest.helpers.topQuarantineReasons(result.quarantine);
+reportPath = did2.unittest.helpers.writeCorpusReport(corpusName, result, reasons);
+
+fprintf('\n=== Corpus %s discovery summary ===\n', corpusName);
+fprintf('total:            %d\n', result.summary.total);
+fprintf('migrated_count:   %d\n', result.summary.migrated_count);
+fprintf('quarantine_count: %d\n', result.summary.quarantine_count);
+fprintf('report:           %s\n', reportPath);
+fprintf('top quarantine reasons:\n');
+for k = 1:min(numel(reasons), 15)
+    fprintf('  %5d  [%s] %s\n', reasons(k).count, ...
+        reasons(k).class_name, reasons(k).reason);
+end
+end

--- a/tests/+did2/+unittest/+helpers/topQuarantineReasons.m
+++ b/tests/+did2/+unittest/+helpers/topQuarantineReasons.m
@@ -1,0 +1,28 @@
+function reasons = topQuarantineReasons(quarantine)
+%TOPQUARANTINEREASONS Aggregate quarantine entries by (class, reason).
+%
+%   REASONS = did2.unittest.helpers.topQuarantineReasons(QUARANTINE) returns
+%   a struct array with fields class_name, reason, count, sorted by
+%   descending count. Empty struct array when QUARANTINE is empty.
+
+if isempty(quarantine)
+    reasons = struct('class_name', {}, 'reason', {}, 'count', {});
+    return;
+end
+keys = cell(1, numel(quarantine));
+for k = 1:numel(quarantine)
+    keys{k} = sprintf('%s|||%s', quarantine(k).class_name, ...
+        quarantine(k).reason);
+end
+[uniqKeys, ~, idx] = unique(keys);
+counts = accumarray(idx, 1);
+reasons = struct('class_name', {}, 'reason', {}, 'count', {});
+for k = 1:numel(uniqKeys)
+    parts = strsplit(uniqKeys{k}, '|||');
+    reasons(k).class_name = parts{1};
+    reasons(k).reason     = parts{2};
+    reasons(k).count      = counts(k);
+end
+[~, order] = sort(-[reasons.count]);
+reasons = reasons(order);
+end

--- a/tests/+did2/+unittest/+helpers/writeCorpusReport.m
+++ b/tests/+did2/+unittest/+helpers/writeCorpusReport.m
@@ -1,0 +1,33 @@
+function reportPath = writeCorpusReport(corpusName, result, reasons)
+%WRITECORPUSREPORT Write a JSON discovery summary under corpus-reports/.
+%
+%   REPORTPATH = did2.unittest.helpers.writeCorpusReport(NAME, RESULT, REASONS)
+%   writes <pwd>/corpus-reports/<NAME>-summary.json containing the
+%   converter summary plus a top-quarantine-reasons table. The CI
+%   workflow's upload-artifact step picks up everything under that
+%   directory.
+
+reportDir = fullfile(pwd, 'corpus-reports');
+if ~exist(reportDir, 'dir')
+    mkdir(reportDir);
+end
+reportPath = fullfile(reportDir, [corpusName '-summary.json']);
+
+report = struct( ...
+    'corpus',            corpusName, ...
+    'generated_at',      char(datetime('now', 'TimeZone', 'UTC', ...
+                            'Format', 'yyyy-MM-dd''T''HH:mm:ss''Z''')), ...
+    'total',             result.summary.total, ...
+    'migrated_count',    result.summary.migrated_count, ...
+    'quarantine_count',  result.summary.quarantine_count, ...
+    'by_class',          result.summary.by_class, ...
+    'quarantine_reasons', reasons);
+
+fid = fopen(reportPath, 'w');
+if fid < 0
+    error('did2:test:reportWriteFailed', ...
+        'Could not open %s for writing.', reportPath);
+end
+cleanup = onCleanup(@() fclose(fid)); %#ok<NASGU>
+fwrite(fid, jsonencode(report, 'PrettyPrint', true));
+end

--- a/tests/+did2/+unittest/testCorpusB.m
+++ b/tests/+did2/+unittest/testCorpusB.m
@@ -1,0 +1,29 @@
+function tests = testCorpusB
+%TESTCORPUSB Discovery-mode end-to-end run against the B corpus.
+%
+%   Pulls B.zip from the public S3 prefix (~17 MB compressed,
+%   ~12,917 v1 documents across ~18 classes), runs every contained
+%   body through did2.convert.v1_to_v2 with Validate=true, and
+%   writes a per-run summary JSON to corpus-reports/B-summary.json.
+%   The workflow's upload-artifact step picks up the file as a CI
+%   artifact.
+%
+%   Discovery mode: the test does not assert zero quarantine. Its
+%   job is to surface coverage signal without blocking unrelated
+%   PRs on migrator work.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testCorpusB');
+
+tests = functiontests(localfunctions);
+end
+
+function teardownOnce(testCase)
+did2.unittest.helpers.restoreSchemaPath(testCase);
+end
+
+function testBCorpusDiscoveryReport(testCase)
+did2.unittest.helpers.runCorpusDiscovery(testCase, 'B', ...
+    'https://ndi-programming-development.s3.us-east-1.amazonaws.com/B.zip', ...
+    'B');
+end

--- a/tests/+did2/+unittest/testCorpusDab.m
+++ b/tests/+did2/+unittest/testCorpusDab.m
@@ -1,0 +1,26 @@
+function tests = testCorpusDab
+%TESTCORPUSDAB Discovery-mode end-to-end run against the Dab corpus.
+%
+%   Pulls Dab.zip from the public S3 prefix (~35 MB compressed,
+%   ~27,561 v1 documents), runs every contained body through
+%   did2.convert.v1_to_v2 with Validate=true, and writes a per-run
+%   summary JSON to corpus-reports/Dab-summary.json. The workflow's
+%   upload-artifact step picks up the file as a CI artifact.
+%
+%   Discovery mode: the test does not assert zero quarantine.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testCorpusDab');
+
+tests = functiontests(localfunctions);
+end
+
+function teardownOnce(testCase)
+did2.unittest.helpers.restoreSchemaPath(testCase);
+end
+
+function testDabCorpusDiscoveryReport(testCase)
+did2.unittest.helpers.runCorpusDiscovery(testCase, 'Dab', ...
+    'https://ndi-programming-development.s3.us-east-1.amazonaws.com/Dab.zip', ...
+    'Dab');
+end

--- a/tests/+did2/+unittest/testCorpusJH.m
+++ b/tests/+did2/+unittest/testCorpusJH.m
@@ -1,0 +1,30 @@
+function tests = testCorpusJH
+%TESTCORPUSJH Discovery-mode end-to-end run against the JH corpus.
+%
+%   Pulls JH.zip from the public S3 prefix (~89 MB compressed,
+%   ~78,688 v1 documents), runs every contained body through
+%   did2.convert.v1_to_v2 with Validate=true, and writes a per-run
+%   summary JSON to corpus-reports/JH-summary.json. The workflow's
+%   upload-artifact step picks up the file as a CI artifact.
+%
+%   Discovery mode: the test does not assert zero quarantine.
+%
+%   This corpus is the largest of the four PR-time discovery
+%   fixtures (B, Dab, JH at ~150 MB combined). Soph (~446 MB) is
+%   guarded separately by DID_RUN_SOPH_TEST.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testCorpusJH');
+
+tests = functiontests(localfunctions);
+end
+
+function teardownOnce(testCase)
+did2.unittest.helpers.restoreSchemaPath(testCase);
+end
+
+function testJHCorpusDiscoveryReport(testCase)
+did2.unittest.helpers.runCorpusDiscovery(testCase, 'JH', ...
+    'https://ndi-programming-development.s3.us-east-1.amazonaws.com/JH.zip', ...
+    'JH');
+end

--- a/tests/+did2/+unittest/testCorpusSoph.m
+++ b/tests/+did2/+unittest/testCorpusSoph.m
@@ -1,0 +1,44 @@
+function tests = testCorpusSoph
+%TESTCORPUSSOPH Discovery-mode end-to-end run against the Soph corpus.
+%
+%   The largest single-corpus discovery fixture (~446 MB compressed,
+%   ~101,427 v1 documents). Too big to download on every PR, so the
+%   test is **opt-in** via the DID_RUN_SOPH_TEST environment
+%   variable:
+%
+%       export DID_RUN_SOPH_TEST=1   # also accepts 'true', case-insensitive
+%
+%   When the variable is unset, empty, '0', or 'false', the test
+%   skips cleanly via assumeFail (no error). When set to '1' or
+%   'true', it downloads Soph.zip, runs the full corpus through
+%   did2.convert.v1_to_v2 with Validate=true, and writes
+%   corpus-reports/Soph-summary.json.
+%
+%   Discovery mode: the test does not assert zero quarantine.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testCorpusSoph');
+
+tests = functiontests(localfunctions);
+end
+
+function teardownOnce(testCase)
+did2.unittest.helpers.restoreSchemaPath(testCase);
+end
+
+function testSophCorpusDiscoveryReport(testCase)
+if ~sophTestEnabled()
+    assumeFail(testCase, ...
+        ['DID_RUN_SOPH_TEST not set to a truthy value; ', ...
+         'skipping the ~446 MB Soph corpus discovery test. ', ...
+         'Set DID_RUN_SOPH_TEST=1 (or true) to enable.']);
+end
+did2.unittest.helpers.runCorpusDiscovery(testCase, 'Soph', ...
+    'https://ndi-programming-development.s3.us-east-1.amazonaws.com/Soph.zip', ...
+    'Soph');
+end
+
+function tf = sophTestEnabled()
+raw = lower(strtrim(getenv('DID_RUN_SOPH_TEST')));
+tf = ismember(raw, {'1', 'true', 'yes', 'y', 'on'});
+end

--- a/tests/+did2/+unittest/testValidateReferences.m
+++ b/tests/+did2/+unittest/testValidateReferences.m
@@ -1,0 +1,170 @@
+function tests = testValidateReferences
+%TESTVALIDATEREFERENCES Unit tests for did2.validate.references.
+%
+%   Exercises the depends_on referential-integrity checker.
+%
+%   Run with:
+%       results = runtests('did2.unittest.testValidateReferences');
+
+tests = functiontests(localfunctions);
+end
+
+% ---- fixture setup / teardown ----
+
+function setupOnce(testCase)
+thisDir = fileparts(mfilename('fullpath'));
+fixtureDir = fullfile(fileparts(thisDir), 'fixtures', 'V_delta');
+did2.schema.cache.setSchemaPath(fixtureDir);
+testCase.TestData.fixtureDir = fixtureDir;
+end
+
+function teardownOnce(~)
+did2.schema.cache.resetSingleton();
+end
+
+% ---- batch-internal resolution ----
+
+function testNoOrphansWhenBatchSelfContained(testCase)
+parent = makeDemoA('parent');
+child  = makeDemoA('child');
+child  = setDependsOn(child, 'parent_id', parent.get('base.id'));
+report = did2.validate.references({parent, child});
+verifyEqual(testCase, report.total_docs, 2);
+verifyEqual(testCase, report.edges_examined, 1);
+verifyEqual(testCase, report.orphan_count, 0);
+end
+
+function testEmptyEdgeValueDoesNotCount(testCase)
+doc = makeDemoA('alice');
+doc = setDependsOn(doc, 'optional_id', '');
+report = did2.validate.references({doc});
+verifyEqual(testCase, report.edges_examined, 0);
+verifyEqual(testCase, report.orphan_count, 0);
+end
+
+function testOrphanEdgeReported(testCase)
+child = makeDemoA('child');
+child = setDependsOn(child, 'parent_id', ...
+    'deadbeefdeadbeef_0000111122223333');
+report = did2.validate.references({child});
+verifyEqual(testCase, report.orphan_count, 1);
+verifyEqual(testCase, report.orphans(1).edge_name, 'parent_id');
+verifyEqual(testCase, report.orphans(1).edge_value, ...
+    'deadbeefdeadbeef_0000111122223333');
+verifyEqual(testCase, report.orphans(1).doc_id, child.get('base.id'));
+verifyEqual(testCase, report.orphans(1).doc_class, 'demoA');
+end
+
+function testMultipleOrphansOnOneDoc(testCase)
+doc = makeDemoA('lonely');
+doc = setDependsOn(doc, ...
+    {'a_id', 'b_id'}, ...
+    {'aaaaaaaaaaaaaaaa_0000111122223333', ...
+     'bbbbbbbbbbbbbbbb_0000111122223333'});
+report = did2.validate.references({doc});
+verifyEqual(testCase, report.edges_examined, 2);
+verifyEqual(testCase, report.orphan_count, 2);
+end
+
+function testMixedResolvedAndOrphan(testCase)
+parent = makeDemoA('parent');
+child  = makeDemoA('child');
+child  = setDependsOn(child, ...
+    {'parent_id', 'missing_id'}, ...
+    {parent.get('base.id'), ...
+     'ccccccccccccccccc_0000111122223333'});
+report = did2.validate.references({parent, child});
+verifyEqual(testCase, report.edges_examined, 2);
+verifyEqual(testCase, report.orphan_count, 1);
+verifyEqual(testCase, report.orphans(1).edge_name, 'missing_id');
+end
+
+% ---- KnownIds extra set ----
+
+function testKnownIdsAllowsOrphanResolution(testCase)
+doc = makeDemoA('child');
+ghostId = 'deadbeefdeadbeef_0000111122223333';
+doc = setDependsOn(doc, 'ghost_id', ghostId);
+report = did2.validate.references({doc}, 'KnownIds', {ghostId});
+verifyEqual(testCase, report.orphan_count, 0);
+end
+
+% ---- database lookup ----
+
+function testDatabaseResolvesOrphanFromPriorBatch(testCase)
+if isempty(which('mksqlite'))
+    assumeFail(testCase, ...
+        'mksqlite is not on the MATLAB path; skipping the DB-backed reference test.');
+end
+tmp = [tempname() '.sqlite'];
+cleanup = onCleanup(@() safeDelete(tmp)); %#ok<NASGU>
+db = did2.database.sqlitedb(tmp);
+parent = makeDemoA('first-batch-parent');
+db.add(parent);
+
+child = makeDemoA('second-batch-child');
+child = setDependsOn(child, 'parent_id', parent.get('base.id'));
+
+batchOnly = did2.validate.references({child});
+verifyEqual(testCase, batchOnly.orphan_count, 1, ...
+    'Edge should be orphan when DB is not consulted.');
+
+withDb = did2.validate.references({child}, 'Database', db);
+verifyEqual(testCase, withDb.orphan_count, 0, ...
+    'Edge should resolve via the DB.');
+end
+
+% ---- input shape variants ----
+
+function testAcceptsStructArrayOfBodies(testCase)
+parent = makeDemoA('p');
+child  = makeDemoA('c');
+child  = setDependsOn(child, 'parent_id', parent.get('base.id'));
+arr = [parent.toStruct(); child.toStruct()];
+report = did2.validate.references(arr);
+verifyEqual(testCase, report.total_docs, 2);
+verifyEqual(testCase, report.orphan_count, 0);
+end
+
+function testAcceptsDocumentObjectArray(testCase)
+parent = makeDemoA('p');
+child  = makeDemoA('c');
+child  = setDependsOn(child, 'parent_id', parent.get('base.id'));
+arr = [parent, child];
+report = did2.validate.references(arr);
+verifyEqual(testCase, report.total_docs, 2);
+verifyEqual(testCase, report.orphan_count, 0);
+end
+
+% ---- helpers ----
+
+function doc = makeDemoA(name)
+doc = did2.document.blank('demoA');
+doc = doc.set('base.session_id', sprintf('session-%s', name));
+doc = doc.set('base.name', name);
+doc = doc.set('demoA.value', name);
+end
+
+function doc = setDependsOn(doc, names, values)
+if ischar(names)
+    names = {names};
+end
+if ischar(values)
+    values = {values};
+end
+deps = struct('name', {}, 'value', {});
+for k = 1:numel(names)
+    deps(end+1) = struct( ...
+        'name',  names{k}, ...
+        'value', values{k}); %#ok<AGROW>
+end
+s = doc.toStruct();
+s.depends_on = deps;
+doc = did2.document(s);
+end
+
+function safeDelete(path)
+if exist(path, 'file')
+    delete(path);
+end
+end


### PR DESCRIPTION
Two follow-ups bundled on one branch.

## 1. `did2.validate.references` for depends_on referential integrity

Closes the open follow-up noted in PR #128 and PR #129 closeouts.

New utility `did2.validate.references` that walks a batch of `did2.document`s and reports every `depends_on[i].value` that does **not** resolve to one of:

- the `base.id` of another doc in the same batch
- (optional) a doc already in a `did2.database.sqlitedb`
- (optional) an id passed in via `KnownIds` (for chained batch imports)

Returns a report rather than throwing — callers decide whether to quarantine, log, or proceed. Empty edge values are skipped (those represent intentionally unfilled optional dependencies per the schema's `mustBeNonEmpty=false`).

### Report shape

```matlab
struct with fields:
  total_docs       % docs inspected
  edges_examined   % non-empty depends_on edges walked
  orphans          % struct array: doc_id, doc_class, edge_name, edge_value
  orphan_count     % numel(orphans)
```

### Wire-in

`did2.convert.v1_to_v2` gains two opt-in options:

- `CheckReferences` (logical, default `false`) — when true, runs `validate.references` against `result.migrated` after the per-doc pipeline finishes. The report lands under `result.references`.
- `ReferenceDatabase` (`did2.database.sqlitedb` or `[]`, default `[]`) — when supplied, edges that resolve to documents already stored in the DB also count as resolved.

Orphan edges are **not** routed to quarantine — quarantine is for documents that fail their own schema validation; orphan edges are a batch-level relationship problem, surfaced separately.

### Tests

`testValidateReferences` (8 cases): batch self-resolution, empty edge skipped, single + multiple orphans, mixed resolved + orphan, `KnownIds` external resolution, DB-backed resolution (skipped without mksqlite), struct-array and `did2.document`-array input shapes.

## 2. B / Dab / JH discovery-mode corpora on every PR; Soph opt-in

Adds four more discovery-mode end-to-end converter tests pulling from the same public S3 prefix as PRED and 20211116:

| test | corpus zip | docs |
|---|---|---|
| `testCorpusB` | ~17 MB | ~12,917 |
| `testCorpusDab` | ~35 MB | ~27,561 |
| `testCorpusJH` | ~89 MB | ~78,688 |
| `testCorpusSoph` | ~446 MB | ~101,427 (opt-in) |

B, Dab, and JH run on every PR. Soph is opt-in via the `DID_RUN_SOPH_TEST` environment variable — unset / empty / `0` / `false` skips cleanly via `assumeFail` (no error); `1` / `true` / `yes` / `y` / `on` (case-insensitive) enables it. Too big to download on every PR.

### Shared helpers

Helpers extracted into a `+did2/+unittest/+helpers/` subpackage so each per-corpus test file is a thin one-liner wrapper around `did2.unittest.helpers.runCorpusDiscovery`:

- `helpers.installSchemaPath` / `helpers.restoreSchemaPath` — DID_SCHEMA_PATH probe + override + safe restore
- `helpers.ensureCorpus` — cached download + unzip into tempdir
- `helpers.runCorpusDiscovery` — full pipeline: download, run, aggregate, write report, log
- `helpers.topQuarantineReasons` / `helpers.writeCorpusReport` — report shaping

### Workflow

No workflow change needed. `TestSuite.fromPackage(..., IncludingSubpackages=true)` already discovers every `test*.m` under `did2.unittest`; the `corpus-reports/` upload-artifact step already runs `if: always()` and `if-no-files-found: ignore`.

## Out of scope

- Wiring `validate.references` into `did2.database.sqlitedb.add` — would change `add()` semantics; deferred until we have a clear story for partial-batch ingest.
- Cycle / depth checks on the dependency graph.
- Adding the four new corpora to the `gate-mode` set (assert zero quarantine). Now that the Python sim shows 0 quarantines across all six corpora, B/Dab/JH/Soph could plausibly become gate-mode like PRED. Left as a follow-up once the MATLAB-side runs come back clean.

https://claude.ai/code/session_011wtV7T1TKrxbGBeW71ebQn