### PR TITLE
did2: enforce superclasses-chain consistency in validateDocument

### DIFF
--- a/src/did/+did2/+convert/v1_to_v2.m
+++ b/src/did/+did2/+convert/v1_to_v2.m
@@ -178,10 +178,14 @@ function body = ensureClassBlocks(body, schemaCacheOverride)
 % Make sure every class in the V_delta schema chain for the body's
 % concrete class has a property block in the document, manufacturing
 % empty `struct()` blocks for any chain entry that the v1 source did
-% not provide. V_delta's validator rejects documents whose chain
-% blocks are missing, so this padding lets the per-class migrators
-% stay focused on real field moves rather than placeholder
-% bookkeeping.
+% not provide. Also rebuilds document_class.superclasses from the
+% V_delta schema chain so the snapshot matches the spec (same set,
+% same order, class-name-by-class-name) even when V_delta has
+% reordered or extended the chain relative to v1. V_delta's
+% validator rejects documents whose chain blocks are missing or
+% whose superclasses snapshot drifts from the schema, so this
+% padding lets the per-class migrators stay focused on real field
+% moves rather than placeholder bookkeeping.
 %
 % Silent no-op if the schema cache cannot resolve the class chain
 % (e.g., the class is unknown to the cache, or the cache itself is
@@ -206,6 +210,7 @@ if isempty(cache)
 end
 try
     chain = cache.classChain(className);
+    ancestors = cache.superclasses(className);
 catch
     return;
 end
@@ -215,6 +220,14 @@ for k = 1:numel(chain)
         body.(cls) = struct();
     end
 end
+sc = struct('class_name', {}, 'class_version', {});
+for k = 1:numel(ancestors)
+    ancDC = cache.getClass(ancestors{k}).document_class;
+    sc(end+1) = struct( ...
+        'class_name',    char(ancDC.class_name), ...
+        'class_version', char(ancDC.class_version)); %#ok<AGROW>
+end
+body.document_class.superclasses = sc;
 end
 
 function body = applySuperclassMigrators(body, concreteClassName)

--- a/src/did/+did2/+schema/cache.m
+++ b/src/did/+did2/+schema/cache.m
@@ -389,6 +389,34 @@ classdef cache < handle
                     ['Class "%s" is declared abstract; documents must ' ...
                      'instantiate a concrete subclass.'], className);
             end
+            % V_gamma_SPEC §"Validation checklist": the
+            % document_class.superclasses snapshot must equal the chain
+            % derived from the schema files (same set, same order,
+            % class-name-by-class-name). buildBlankDocument and the
+            % v1->v2 migrator both honour this by construction; this
+            % check catches hand-built docs and serialisers that emit
+            % only the immediate parent — a truncated chain breaks
+            % isa-style queries downstream (e.g., classLineage on the
+            % cloud), so flag it at the boundary.
+            if ~isfield(dc, 'superclasses')
+                error('did2:validation:missingSuperclasses', ...
+                    ['document_class.superclasses is required (empty ' ...
+                     '[] for base). Class "%s" expects %d entries.'], ...
+                    className, numel(obj.superclasses(className)));
+            end
+            expectedAncestors = obj.superclasses(className);
+            declaredAncestors = obj.superclassClassNames(dc.superclasses);
+            if numel(declaredAncestors) ~= numel(expectedAncestors) ...
+                    || ~all(cellfun(@strcmp, declaredAncestors, expectedAncestors))
+                error('did2:validation:superclassesChainMismatch', ...
+                    ['document_class.superclasses for "%s" is {%s} but ' ...
+                     'the schema chain is {%s}. V_delta requires the ' ...
+                     'snapshot to match the schema-derived chain ' ...
+                     'class-name-by-class-name.'], ...
+                    className, ...
+                    strjoin(declaredAncestors, ', '), ...
+                    strjoin(expectedAncestors, ', '));
+            end
             chain = obj.classChain(className);
             for k = 1:numel(chain)
                 blockClass = chain{k};
@@ -581,6 +609,31 @@ classdef cache < handle
         function elem = elementAt(obj, raw, idx)
             cells = obj.toCellArray(raw);
             elem = cells{idx};
+        end
+
+        function names = superclassClassNames(obj, raw)
+            % Extract the class_name from each entry of a
+            % document_class.superclasses array. Accepts the empty
+            % array `[]` (jsondecode of `[]`), an empty struct array,
+            % a single struct, or an N-element struct array. Raises
+            % did2:validation:badSuperclassEntry on malformed entries.
+            if isempty(raw)
+                names = {};
+                return;
+            end
+            cells = obj.toCellArray(raw);
+            names = cell(1, numel(cells));
+            for k = 1:numel(cells)
+                entry = cells{k};
+                if ~isstruct(entry) || ~isfield(entry, 'class_name') ...
+                        || isempty(entry.class_name)
+                    error('did2:validation:badSuperclassEntry', ...
+                        ['document_class.superclasses(%d) is missing ' ...
+                         'class_name; every snapshot entry must carry ' ...
+                         'at least class_name.'], k);
+                end
+                names{k} = char(entry.class_name);
+            end
         end
 
         function block = buildBlockForClass(obj, className)

--- a/tests/+did2/+unittest/testSchemaCache.m
+++ b/tests/+did2/+unittest/testSchemaCache.m
@@ -211,6 +211,82 @@ verifyError(testCase, ...
     'did2:validation:missingClassBlock');
 end
 
+function testValidateTruncatedSuperclassesChainThrows(testCase)
+% V_gamma_SPEC "Validation checklist": the document_class.superclasses
+% snapshot must match the schema-derived chain. demoB's chain is
+% {demoA, base}; truncating to {demoA} must fail loudly so consumers
+% (e.g., cloud classLineage) get a complete is-a transitive closure.
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoB');
+doc.base.session_id = did.ido.unique_id();
+doc.demoA.value = 'x';
+doc.demoB.value_b = 'y';
+% Sanity: blank doc validates first.
+cache.validateDocument(doc);
+truncated = doc;
+truncated.document_class.superclasses = ...
+    doc.document_class.superclasses(1);
+verifyError(testCase, ...
+    @() cache.validateDocument(truncated), ...
+    'did2:validation:superclassesChainMismatch');
+end
+
+function testValidateReorderedSuperclassesChainThrows(testCase)
+% Spec requires same order, not just same set.
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoB');
+doc.base.session_id = did.ido.unique_id();
+doc.demoA.value = 'x';
+doc.demoB.value_b = 'y';
+reordered = doc;
+reordered.document_class.superclasses = ...
+    doc.document_class.superclasses([2 1]);
+verifyError(testCase, ...
+    @() cache.validateDocument(reordered), ...
+    'did2:validation:superclassesChainMismatch');
+end
+
+function testValidateMissingSuperclassesFieldThrows(testCase)
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoA');
+doc.base.session_id = did.ido.unique_id();
+doc.demoA.value = 'x';
+doc.document_class = rmfield(doc.document_class, 'superclasses');
+verifyError(testCase, ...
+    @() cache.validateDocument(doc), ...
+    'did2:validation:missingSuperclasses');
+end
+
+function testValidateBadSuperclassEntryThrows(testCase)
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoA');
+doc.base.session_id = did.ido.unique_id();
+doc.demoA.value = 'x';
+doc.document_class.superclasses(1).class_name = '';
+verifyError(testCase, ...
+    @() cache.validateDocument(doc), ...
+    'did2:validation:badSuperclassEntry');
+end
+
+function testValidateBaseAcceptsEmptySuperclasses(testCase)
+% Spec: superclasses must be `[]` for base. buildBlankDocument cannot
+% mint a `base` doc (`base` lacks the concrete declarations it needs),
+% so build the smallest valid base doc by hand and confirm it passes.
+cache = testCase.TestData.cache;
+doc = struct();
+doc.document_class = struct( ...
+    'class_name',    'base', ...
+    'class_version', '1.0.0', ...
+    'superclasses',  []);
+doc.depends_on = struct('name', {}, 'value', {});
+doc.base = struct( ...
+    'id',         did.ido.unique_id(), ...
+    'session_id', did.ido.unique_id(), ...
+    'name',       'rig_1', ...
+    'datestamp',  '2026-01-01T00:00:00.000Z');
+cache.validateDocument(doc);
+end
+
 % ---- end-to-end through did2.document ----
 
 function testDocumentBlankConvenience(testCase)


### PR DESCRIPTION
## Summary

Closes the last gap between V_delta's spec and did2-matlab's validator: `document_class.superclasses` must equal the schema-derived chain class-name-by-class-name (V_gamma_SPEC.md §"Validation checklist", inherited unchanged by V_delta per `conversions/from_did_v1/_universal_renames.md` §4).

`validateDocument` previously only required one property block per chain class — a hand-built or partially-migrated doc could pass with a truncated or reordered `superclasses` array, which silently breaks transitive `isa` queries downstream. The clearest example is ndi-cloud-node's `classLineage` field, which is computed from `document_class.superclasses[*].class_name` and never independently resolves the schema chain — so the writer must emit the full transitive closure.

## Changes

- **`src/did/+did2/+schema/cache.m`**: `validateDocument` now compares `dc.superclasses` to `obj.superclasses(className)` and raises one of three errors on drift:
  - `did2:validation:missingSuperclasses` — the field is absent.
  - `did2:validation:badSuperclassEntry` — an entry lacks `class_name`.
  - `did2:validation:superclassesChainMismatch` — wrong length, wrong order, or wrong names.

  Added a small `superclassClassNames` helper that normalises the `[]` / scalar-struct / struct-array shapes the same way the existing BFS does.

- **`src/did/+did2/+convert/v1_to_v2.m`**: `ensureClassBlocks` now also rebuilds `document_class.superclasses` from the schema cache after per-class migrators run. Necessary because the v1→v2 pipeline previously preserved the v1 chain verbatim — when V_delta has reordered or extended the chain (e.g., `oridirtuning_calc` adding `tuning_fit`), the migrated doc would now fail the new check. Migrators still see the v1-shaped chain when they dispatch; the rewrite happens after.

- **`tests/+did2/+unittest/testSchemaCache.m`**: five new tests covering truncated chain, reordered chain, missing-field, malformed-entry, and `base`'s legitimate empty-chain case.

## Why this matters for the NDI-matlab did2 migration

ndi-cloud-node's `classLineage` is the index backing `isa` queries. It's populated from the document's `document_class.superclasses` array verbatim — no schema traversal, no graph walk. The cloud trusts the writer. This change makes the writer trustworthy by failing loudly the moment a non-spec-compliant chain shows up, rather than letting it ship to Mongo and silently miss documents on every ancestor-class query.

## Test plan

- [ ] `did2.unittest.testSchemaCache` passes (new chain-consistency tests).
- [ ] `did2.unittest.testConvertV1ToV2` passes (verifies the migrator rebuild).
- [ ] Corpus tests (B, Dab, JH, PRED, Soph) still pass — they exercise the v1→v2 path that the migrator change touches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtHfxqZ6bqCSFoNFmS2h7E)_