### PR TITLE
Add idempotency short-circuit to v1_to_v2 converter

### DIFF
--- a/src/did/+did2/+convert/v1_to_v2.m
+++ b/src/did/+did2/+convert/v1_to_v2.m
@@ -17,6 +17,13 @@ function result = v1_to_v2(v1Bodies, options)
 %        placeholder blocks for inherited classes. Silent no-op if
 %        the schema cache cannot resolve the chain.
 %
+%   Bodies that are already V_delta-shaped (base.schema_version ==
+%   'V_delta' AND no v1-only underscore-prefixed top-level markers)
+%   short-circuit steps 1-3 and go straight to ensureClassBlocks +
+%   validate. Makes the converter safely re-runnable so a partial
+%   normalisation or migration run can resume after an interruption
+%   without corrupting already-converted docs.
+%
 %   Documents that fail any step land in the quarantine table; nothing
 %   is silently dropped.
 %
@@ -82,11 +89,27 @@ for k = 1:numel(bodies)
     className = '<unknown>';
     try
         preBody = ensureStruct(rawBody);
-        postUniversalBody = did2.convert.universalRenames(preBody);
-        className = char(postUniversalBody.document_class.class_name);
-        v2Body = applySuperclassMigrators(postUniversalBody, className);
-        migratorFcn = lookupMigrator(className);
-        v2Body = migratorFcn(v2Body);
+        if isAlreadyVDelta(preBody)
+            % Idempotency short-circuit: the body is already V_delta,
+            % so skip universalRenames and the per-class migrators.
+            % ensureClassBlocks still runs (it rebuilds the V_delta
+            % superclass chain — required) and validate still runs
+            % (gate against drift). Keeps the database normalisation
+            % and migration commands safely re-runnable after an
+            % interruption.
+            v2Body = preBody;
+            if isfield(v2Body, 'document_class') ...
+                    && isstruct(v2Body.document_class) ...
+                    && isfield(v2Body.document_class, 'class_name')
+                className = char(v2Body.document_class.class_name);
+            end
+        else
+            postUniversalBody = did2.convert.universalRenames(preBody);
+            className = char(postUniversalBody.document_class.class_name);
+            v2Body = applySuperclassMigrators(postUniversalBody, className);
+            migratorFcn = lookupMigrator(className);
+            v2Body = migratorFcn(v2Body);
+        end
         v2Body = ensureClassBlocks(v2Body, options.SchemaCache);
         doc = did2.document(v2Body);
         if options.Validate
@@ -163,6 +186,47 @@ else
     error('did2:convert:badInput', ...
         'v1 body must be a scalar struct or JSON char (got %s).', class(body));
 end
+end
+
+function tf = isAlreadyVDelta(body)
+% Return true when BODY is already a V_delta-shaped document so the
+% per-body migration loop can skip universalRenames and the per-class
+% migrators. Both conditions must hold so the short-circuit only fires
+% when we have high confidence the body is V_delta:
+%   (a) base.schema_version is the literal char 'V_delta' (set by the
+%       last run of universalRenames, or by the writer), AND
+%   (b) the body carries no v1-only structural markers — underscore-
+%       prefixed top-level keys (e.g., legacy _classname,
+%       _class_version) that predate the document_class header and
+%       could not survive a real V_delta build.
+%
+% (a) alone would misclassify a body that was tagged V_delta out-of-
+% band but still carries legacy field shapes; (b) alone would skip
+% the bulk of v1 corpora, which do not happen to use the underscore
+% markers but still need every other v1->V_delta rewrite.
+tf = false;
+if ~isstruct(body) || ~isscalar(body)
+    return;
+end
+if ~isfield(body, 'base') || ~isstruct(body.base) || ~isscalar(body.base) ...
+        || ~isfield(body.base, 'schema_version')
+    return;
+end
+sv = body.base.schema_version;
+if isstring(sv) && isscalar(sv)
+    sv = char(sv);
+end
+if ~ischar(sv) || ~strcmp(sv, 'V_delta')
+    return;
+end
+topKeys = fieldnames(body);
+for k = 1:numel(topKeys)
+    name = topKeys{k};
+    if ~isempty(name) && name(1) == '_'
+        return;
+    end
+end
+tf = true;
 end
 
 function fcn = lookupMigrator(className)

--- a/tests/+did2/+unittest/testConvertV1ToV2.m
+++ b/tests/+did2/+unittest/testConvertV1ToV2.m
@@ -240,3 +240,123 @@ verifyEqual(testCase, doc.get('epochclocktimes.epoch_clock'), ...
 verifyEqual(testCase, doc.get('epochclocktimes.t0'), 0);
 verifyEqual(testCase, doc.get('epochclocktimes.t1'), 1.5);
 end
+
+function vDelta = makeVDeltaSkeleton(className)
+% Build a body that is already V_delta-shaped: schema_version stamped,
+% snake-cased class name, depends_on uses `value` (not `id`).
+vDelta = struct();
+vDelta.document_class = struct( ...
+    'class_name',    className, ...
+    'class_version', '1.0.0', ...
+    'superclasses',  struct( ...
+        'class_name',    'base', ...
+        'class_version', '1.0.0'));
+vDelta.depends_on = struct('name', {}, 'value', {});
+vDelta.base = struct( ...
+    'id',             'aabb1122ccdd3344_1122334455667788', ...
+    'session_id',     'aabb1122ccdd3344_9900aabbccddeeff', ...
+    'name',           'unit-test', ...
+    'datestamp',      '2024-06-01T12:00:00.000Z', ...
+    'schema_version', 'V_delta');
+end
+
+function testShortCircuitOnAlreadyVDeltaBody(testCase)
+% A body that already declares base.schema_version=='V_delta' skips
+% universalRenames and the per-class migrators. The epochclocktimes
+% block carries v1-shaped fields (clocktype, t0_t1); under the short-
+% circuit those stay verbatim because the superclass migrator never
+% runs. ensureClassBlocks still runs (rebuilds the chain) and the
+% body still becomes a did2.document.
+vDelta = makeVDeltaSkeleton('some_unregistered_class');
+vDelta.some_unregistered_class = struct('foo', 'bar');
+vDelta.epochclocktimes = struct('clocktype', 'dev_local_time', ...
+    't0_t1', [0 1.5]);
+vDelta.document_class.superclasses = struct( ...
+    'class_name', {'base', 'epochclocktimes'});
+result = did2.convert.v1_to_v2(vDelta, 'Validate', false);
+verifyEqual(testCase, result.summary.migrated_count, 1);
+verifyEqual(testCase, result.summary.quarantine_count, 0);
+doc = result.migrated{1};
+verifyEqual(testCase, doc.get('epochclocktimes.clocktype'), ...
+    'dev_local_time');
+verifyEqual(testCase, doc.get('epochclocktimes.t0_t1'), [0 1.5]);
+verifyEqual(testCase, doc.get('base.schema_version'), 'V_delta');
+% Per-class summary keys off the unchanged class_name.
+verifyEqual(testCase, result.summary.by_class.some_unregistered_class, 1);
+end
+
+function testIdempotencyOfDoubleRun(testCase)
+% Running v1_to_v2 twice on the same v1 body produces the same
+% migrated output the second time as the first. The second pass hits
+% the short-circuit because the first pass stamped schema_version.
+v1 = makeV1Skeleton('some_unregistered_class');
+v1.some_unregistered_class = struct('foo', 'bar');
+v1.epochclocktimes = struct('clocktype', 'dev_local_time', ...
+    't0_t1', [0 1.5]);
+v1.document_class.superclasses = struct( ...
+    'class_name', {'base', 'epochclocktimes'});
+
+first = did2.convert.v1_to_v2(v1, 'Validate', false);
+verifyEqual(testCase, first.summary.migrated_count, 1);
+firstBody = first.migrated{1}.toStruct();
+
+second = did2.convert.v1_to_v2(firstBody, 'Validate', false);
+verifyEqual(testCase, second.summary.migrated_count, 1);
+verifyEqual(testCase, second.summary.quarantine_count, 0);
+secondBody = second.migrated{1}.toStruct();
+
+verifyEqual(testCase, secondBody.base.schema_version, 'V_delta');
+verifyEqual(testCase, secondBody.epochclocktimes.epoch_clock, ...
+    'dev_local_time');
+verifyEqual(testCase, secondBody.epochclocktimes.t0, 0);
+verifyEqual(testCase, secondBody.epochclocktimes.t1, 1.5);
+verifyEqual(testCase, secondBody, firstBody);
+end
+
+function testMixedBatchOfV1AndVDeltaBodies(testCase)
+% A batch with both v1 bodies (need full migration) and V_delta
+% bodies (short-circuit) migrates every document successfully.
+v1A = makeV1Skeleton('unknown_class');
+v1A.unknown_class = struct('foo', 'bar_v1');
+vDeltaA = makeVDeltaSkeleton('unknown_class');
+vDeltaA.unknown_class = struct('foo', 'bar_vdelta');
+v1B = makeV1Skeleton('some_other_class');
+v1B.some_other_class = struct('n', 42);
+vDeltaB = makeVDeltaSkeleton('some_other_class');
+vDeltaB.some_other_class = struct('n', 99);
+
+result = did2.convert.v1_to_v2( ...
+    {v1A, vDeltaA, v1B, vDeltaB}, 'Validate', false);
+
+verifyEqual(testCase, result.summary.total, 4);
+verifyEqual(testCase, result.summary.migrated_count, 4);
+verifyEqual(testCase, result.summary.quarantine_count, 0);
+verifyEqual(testCase, result.summary.by_class.unknown_class, 2);
+verifyEqual(testCase, result.summary.by_class.some_other_class, 2);
+% Every migrated doc carries the V_delta schema_version stamp (v1
+% bodies pick it up from universalRenames; V_delta bodies kept their
+% own).
+for k = 1:numel(result.migrated)
+    doc = result.migrated{k};
+    verifyEqual(testCase, doc.get('base.schema_version'), 'V_delta');
+end
+end
+
+function testShortCircuitSkippedWhenSchemaVersionMissing(testCase)
+% A body that lacks base.schema_version takes the full pipeline even
+% when it has no v1-only underscore markers. Guards against the
+% "either condition is enough" reading that would silently skip
+% bulk v1 corpora.
+v1 = makeV1Skeleton('treatment');
+v1.treatment = struct('ontology_name', 'chebi:6015', 'name', ...
+    'isoflurane', 'numeric_value', 2.0, 'string_value', '2 percent');
+result = did2.convert.v1_to_v2(v1, 'Validate', false);
+verifyEqual(testCase, result.summary.migrated_count, 1);
+doc = result.migrated{1};
+% universalRenames ran: schema_version got stamped.
+verifyEqual(testCase, doc.get('base.schema_version'), 'V_delta');
+% treatment migrator ran: ontology_name + name collapsed into
+% treatment_name (ontology_term composite).
+verifyTrue(testCase, isfield(doc.toStruct().treatment, 'treatment_name'));
+end
+

--- a/tests/+did2/+unittest/testConvertV1ToV2.m
+++ b/tests/+did2/+unittest/testConvertV1ToV2.m
@@ -347,16 +347,25 @@ function testShortCircuitSkippedWhenSchemaVersionMissing(testCase)
 % when it has no v1-only underscore markers. Guards against the
 % "either condition is enough" reading that would silently skip
 % bulk v1 corpora.
-v1 = makeV1Skeleton('treatment');
-v1.treatment = struct('ontology_name', 'chebi:6015', 'name', ...
-    'isoflurane', 'numeric_value', 2.0, 'string_value', '2 percent');
+v1 = makeV1Skeleton('unknown_class');
+v1.unknown_class = struct('foo', 'bar');
+% v1-shaped depends_on: carries `id`, no `value` — universalRenames
+% promotes id->value, drops the legacy keys.
+v1.depends_on = struct( ...
+    'name', {'subject_id'}, ...
+    'id',   {'aabb1122ccdd3344_aaaa1111bbbb2222'}, ...
+    'version', {'1'});
 result = did2.convert.v1_to_v2(v1, 'Validate', false);
 verifyEqual(testCase, result.summary.migrated_count, 1);
 doc = result.migrated{1};
 % universalRenames ran: schema_version got stamped.
 verifyEqual(testCase, doc.get('base.schema_version'), 'V_delta');
-% treatment migrator ran: ontology_name + name collapsed into
-% treatment_name (ontology_term composite).
-verifyTrue(testCase, isfield(doc.toStruct().treatment, 'treatment_name'));
+% universalRenames ran: depends_on(1).id was promoted to .value, and
+% the legacy id/version keys were dropped.
+dependsOn = doc.toStruct().depends_on;
+verifyEqual(testCase, dependsOn(1).value, ...
+    'aabb1122ccdd3344_aaaa1111bbbb2222');
+verifyFalse(testCase, isfield(dependsOn, 'id'));
+verifyFalse(testCase, isfield(dependsOn, 'version'));
 end
 


### PR DESCRIPTION
## Summary
Implements an idempotency short-circuit in the v1-to-v2 document converter to safely handle re-runs and mixed batches of already-converted and unconverted documents. Documents that are already V_delta-shaped skip the expensive universalRenames and per-class migrators, making the converter safely re-runnable after interruptions.

## Key Changes
- **Added `isAlreadyVDelta()` helper function** that detects V_delta-shaped documents by checking two conditions:
  - `base.schema_version == 'V_delta'` (set by universalRenames or external writers)
  - Absence of v1-only underscore-prefixed top-level keys (legacy structural markers)
  - Both conditions must hold to avoid misclassifying partially-converted or out-of-band-tagged documents

- **Modified main conversion loop** to short-circuit when `isAlreadyVDelta()` returns true:
  - Skips `universalRenames` and per-class migrators
  - Still runs `ensureClassBlocks` (rebuilds superclass chain) and validation
  - Preserves already-migrated field shapes verbatim

- **Added comprehensive test coverage**:
  - `testShortCircuitOnAlreadyVDeltaBody`: Verifies v1-shaped fields are preserved when short-circuiting
  - `testIdempotencyOfDoubleRun`: Confirms running converter twice produces identical output
  - `testMixedBatchOfV1AndVDeltaBodies`: Tests batches with both v1 and V_delta documents
  - `testShortCircuitSkippedWhenSchemaVersionMissing`: Guards against incomplete short-circuit conditions

## Implementation Details
- The dual-condition check prevents silent skipping of bulk v1 corpora that lack underscore markers but still need full migration
- Short-circuited documents still go through `ensureClassBlocks` to maintain schema consistency
- Enables safe resumption of partial migration runs without corrupting already-converted documents

https://claude.ai/code/session_01PcQ9ZBthfXnHaiNcQhQLQd