### PR TITLE
did.query: fix shape-strict eqlen check on struct input

### DIFF
--- a/src/did/+did/query.m
+++ b/src/did/+did/query.m
@@ -113,8 +113,13 @@ classdef query
                 query_struct = did.datastructures.emptystruct('field','operation','param1','param2');
             elseif nargin == 1
                 if isstruct(field)
-                    % check arguments
-                    if ~did.datastructures.eqlen(sort(fieldnames(field)),sort({'field','operation','param1','param2'}))
+                    % Validate fieldnames against the expected set.
+                    % fieldnames() returns a 4x1 cell, so build the
+                    % literal as a column too — did.datastructures.eqlen
+                    % checks shape strictly, and a 1x4 vs 4x1 mismatch
+                    % otherwise rejects every well-formed struct input.
+                    if ~did.datastructures.eqlen(sort(fieldnames(field)), ...
+                            sort({'field';'operation';'param1';'param2'}))
                         error('Field names of search structure do not match expected fields.');
                     end
                     query_struct = field;

--- a/tests/+did/+unittest/test_query.m
+++ b/tests/+did/+unittest/test_query.m
@@ -40,5 +40,27 @@ classdef test_query < matlab.unittest.TestCase
             testCase.verifyEqual(q_or.searchstructure.param2(1).operation, 'greaterthan');
             testCase.verifyEqual(q_or.searchstructure.param2(1).param1, 30);
         end
+
+        function test_struct_input_accepted(testCase)
+            % did.query accepts a pre-built searchstructure as a
+            % one-arg input. Regression test for the shape-strict
+            % eqlen check that previously rejected every struct
+            % input because sort(fieldnames(...)) returns a 4x1
+            % cell and the validator compared it against a 1x4
+            % cell literal.
+            ss = struct('field', 'base.name', 'operation', 'exact_string', ...
+                'param1', 'myname', 'param2', '');
+            q = did.query(ss);
+            testCase.verifyEqual(q.searchstructure.field, 'base.name');
+            testCase.verifyEqual(q.searchstructure.operation, 'exact_string');
+            testCase.verifyEqual(q.searchstructure.param1, 'myname');
+        end
+
+        function test_struct_input_rejects_unknown_fields(testCase)
+            % The shape fix must NOT loosen the field-set check.
+            ss = struct('field', 'base.name', 'operation', 'exact_string', ...
+                'param1', 'myname', 'extra', 'X');
+            testCase.verifyError(@() did.query(ss), '');
+        end
     end
 end


### PR DESCRIPTION
## Summary

`did.query`'s one-arg struct-input branch validates that the input struct carries exactly `{field, operation, param1, param2}`. The check used a shape-strict comparison:

```matlab
eqlen(sort(fieldnames(field)), sort({'field','operation','param1','param2'}))
```

`sort(fieldnames(...))` returns a `4x1` cell; the literal is `1x4`. `eqlen` routes through `sizeeq`, which requires identical sizes, so the validator rejected **every** well-formed struct input regardless of field membership. The struct-input form has been latent-broken since this code was written.

Surfaced by [VH-Lab/NDI-matlab#799](https://github.com/VH-Lab/NDI-matlab/pull/799) (the `[did2 #6]` read-time augmentation work): an acceptance test that constructed `ndi.query` from a pre-built searchstructure tripped the check. NDI-matlab side worked around it by swapping the test to the cell-input form, but the underlying `did.query` bug remained.

## Fix

Build the expected-fields literal as a column (`{'field';'operation';...}`) so `sort()` returns `4x1` on both sides. Field-set semantics are unchanged — membership and count are still strict.

## Test plan

- `test_struct_input_accepted` — a well-formed searchstructure now round-trips through `did.query(struct)` as documented in the header comment of the constructor.
- `test_struct_input_rejects_unknown_fields` — an extra field still errors (regression guard so the shape fix doesn't accidentally loosen the validator).

The existing 4 tests in `test_query.m` continue to pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NegxHb86K1Hc1r3BBKdKQ6)_