### PR TITLE
did: fix CI failures from ndi-matlab#802 follow-up (doc2sql orientation, validator reverse lookup)

### DIFF
--- a/src/did/+did/+implementations/doc2sql.m
+++ b/src/did/+did/+implementations/doc2sql.m
@@ -49,10 +49,17 @@ function sqlMetaData = doc2sql(doc)
 
     dependsOn = getField(doc_props, 'depends_on');
     if isstruct(dependsOn)
-        targets = arrayfun(@(e) did.document.i_readDependencyTarget(e), ...
-            dependsOn, 'UniformOutput', false);
-        allData = [{dependsOn.name}; targets];
-        dependsOn = sprintf('%s,%s;',allData{:});
+        % Build a 2xN cell of (name, target) pairs by index. Direct
+        % cell-of-fields concatenation tripped MATLAB:catenate:dimensionMismatch
+        % when dependsOn was a column struct array vs a row, since
+        % {struct.field} and arrayfun return different orientations.
+        n = numel(dependsOn);
+        allData = cell(2, n);
+        for k = 1:n
+            allData{1, k} = dependsOn(k).name;
+            allData{2, k} = did.document.i_readDependencyTarget(dependsOn(k));
+        end
+        dependsOn = sprintf('%s,%s;', allData{:});
     end
     sqlMetaData.columns(end+1) = newColumn('depends_on', dependsOn);
 

--- a/src/did/+did/database.m
+++ b/src/did/+did/database.m
@@ -1367,7 +1367,21 @@ classdef (Abstract) database < matlab.mixin.SetGet   %#ok<*AGROW>
                             definition = expected(idx);
                             subfield = definition.name;
                             field_name = [field '.' subfield];
-                            docSubValue = docValue.(subfield);
+                            % Tolerate V_alpha->V_delta property-block
+                            % renames the schema does not know about:
+                            % if the schema's declared subfield isn't on
+                            % the body, look for the V_delta canonical
+                            % via the rename map. See #801.
+                            if isfield(docValue, subfield)
+                                docSubValue = docValue.(subfield);
+                            else
+                                aliased = did.document.i_aliasV_alphaToV_delta(field, subfield);
+                                if ~isempty(aliased) && isfield(docValue, aliased)
+                                    docSubValue = docValue.(aliased);
+                                else
+                                    docSubValue = docValue.(subfield); % fire the original error
+                                end
+                            end
                             database_obj.validate_field_type_and_value(doc_name, field_name, docSubValue, definition)
                         end
                 end

--- a/src/did/+did/document.m
+++ b/src/did/+did/document.m
@@ -699,19 +699,18 @@ classdef document
             %
             % Currently covers only `daqmetadatareader.reader_class`
             % (V_delta) -> `ndi_daqmetadatareader_class` (V_alpha).
-            % Extend the rename map below as additional block-level
-            % renames surface. The probe_location / treatment /
-            % ontology_image / ontology_label rows are
-            % subfield-level (location.node, treatment_name.node, ...)
-            % and do not appear as direct property-block fields, so
-            % they're not in this table.
+            % Extend the rename map (i_propertyBlockRenameMap) as
+            % additional block-level renames surface. The
+            % probe_location / treatment / ontology_image /
+            % ontology_label rows are subfield-level
+            % (location.node, treatment_name.node, ...) and do not
+            % appear as direct property-block fields, so they're
+            % not in this table.
             arguments
                 blockName (1,:) char
                 names cell
             end
-            renames = containers.Map( ...
-                {'daqmetadatareader.reader_class'}, ...
-                {'ndi_daqmetadatareader_class'});
+            renames = did.document.i_propertyBlockRenameMap();
             for k = 1:numel(names)
                 key = [blockName '.' names{k}];
                 if isKey(renames, key)
@@ -719,6 +718,50 @@ classdef document
                 end
             end
         end % i_normalizePropertyBlockFields
+
+        function aliased = i_aliasV_alphaToV_delta(blockName, vAlphaName)
+            % i_aliasV_alphaToV_delta - inverse of the rename map
+            % above: given a V_alpha legacy field name (e.g.,
+            % `ndi_daqmetadatareader_class`), return the V_delta
+            % canonical name (e.g., `reader_class`). Returns '' if
+            % the name is not aliased.
+            %
+            % Used by did.database/validate_doc_vs_schema when the
+            % schema-declared subfield isn't on the V_delta body and
+            % we need to look up the body via the V_delta-renamed
+            % key.
+            arguments
+                blockName (1,:) char
+                vAlphaName (1,:) char
+            end
+            renames = did.document.i_propertyBlockRenameMap();
+            % Map values back to keys: O(N) iteration is fine for
+            % the tiny rename table.
+            allKeys = renames.keys();
+            for k = 1:numel(allKeys)
+                key = allKeys{k};
+                if strcmp(renames(key), vAlphaName)
+                    % key has the form "<block>.<vDeltaName>".
+                    dotIdx = find(key == '.', 1, 'first');
+                    if isempty(dotIdx), continue; end
+                    keyBlock = key(1:dotIdx-1);
+                    if strcmp(keyBlock, blockName)
+                        aliased = key(dotIdx+1:end);
+                        return;
+                    end
+                end
+            end
+            aliased = '';
+        end % i_aliasV_alphaToV_delta
+
+        function map = i_propertyBlockRenameMap()
+            % i_propertyBlockRenameMap - source-of-truth rename map
+            % for V_alpha <-> V_delta property-block field renames.
+            % Keys: "<block>.<v_delta_name>". Values: V_alpha name.
+            map = containers.Map( ...
+                {'daqmetadatareader.reader_class'}, ...
+                {'ndi_daqmetadatareader_class'});
+        end % i_propertyBlockRenameMap
 
         function body = i_normalizeDependsOn(body)
             % i_normalizeDependsOn - canonicalise depends_on entry


### PR DESCRIPTION
Follow-up to [#138](https://github.com/VH-Lab/DID-matlab/pull/138). Two regressions my #138 fixes introduced, surfaced by the next ndi-matlab #802 CI run:

## 1. `doc2sql` vertcat dimension mismatch

My #138 fix:
```matlab
targets = arrayfun(@(e) did.document.i_readDependencyTarget(e), dependsOn, 'UniformOutput', false);
allData = [{dependsOn.name}; targets];
```

`arrayfun` preserves the input struct array's orientation, but `{struct.field}` always returns a row regardless. When `dependsOn` is a column struct array, the two have different orientations and `vertcat` fails with `MATLAB:catenate:dimensionMismatch`.

Rewritten to a plain for-loop that fills a preallocated `2×N` cell. Orientation-independent.

## 2. validator subfield-loop V_alpha lookup

My #138 field-set normalization accepts that the V_delta body uses `reader_class` where the schema declares `ndi_daqmetadatareader_class`. The next loop (line ~1370) then iterates the schema's subfields and does `docValue.(subfield)` with the V_alpha name — which doesn't exist on the V_delta body.

Added `did.document.i_aliasV_alphaToV_delta(block, vAlphaName)`. When the dot-access would fail, look up the V_delta canonical via the rename map and try that name instead. The original error still fires on truly missing fields.

The forward map (`i_normalizePropertyBlockFields`) and the reverse helper now share a single source-of-truth table via the new `i_propertyBlockRenameMap()`.

## Coordination

ndi-matlab #802 needs a CI re-trigger once this lands. Pushing the matching `normalizeDependsOn` empty-array fix on that side concurrently.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NegxHb86K1Hc1r3BBKdKQ6)_