### PR TITLE
Add RenameClassNames option to preserve legacy identifier spellings

### DIFF
--- a/src/did/+did2/+convert/universalRenames.m
+++ b/src/did/+did2/+convert/universalRenames.m
@@ -1,4 +1,4 @@
-function postBody = universalRenames(preBody)
+function postBody = universalRenames(preBody, options)
 %UNIVERSALRENAMES Apply did_v1 -> V_delta universal renames.
 %
 %   POSTBODY = did2.convert.universalRenames(PREBODY) returns a copy of
@@ -7,21 +7,34 @@ function postBody = universalRenames(preBody)
 %   applied. Per-class migrators run after this pass and assume their
 %   input is the semi-V_delta shape produced here.
 %
+%   POSTBODY = did2.convert.universalRenames(PREBODY, 'RenameClassNames', false)
+%   skips the identifier-level snake_case sweep: document_class.class_name,
+%   document_class.superclasses[i].class_name, top-level property-block
+%   keys, and field names inside property blocks are left untouched.
+%   Callers reading bodies whose schemas still spell identifiers in
+%   the legacy (camelCase) form pass false so the body stays
+%   schema-compatible while still gaining the V_delta shape
+%   transformations (schema_version stamping, base reconciliation,
+%   app block renames, depends_on rewrite). Default is true (full
+%   V_delta normalisation).
+%
 %   Transformations applied:
 %
 %     - snake_case document_class.class_name (e.g., ontologyImage ->
 %       ontology_image) and rename the matching top-level property
-%       block key in lockstep.
+%       block key in lockstep. [gated by RenameClassNames]
 %     - normalise document_class.superclasses[i] entries: derive
 %       class_name from a v1 `definition` path when absent (the
 %       basename of the path, stripped of `.json`), and snake_case
-%       the result.
+%       the result. [snake_case gated by RenameClassNames; the
+%       derivation from definition runs unconditionally]
 %     - field-level snake_case pass inside every class property block
 %       (e.g., pyraview.nativeRate -> pyraview.native_rate,
 %       pyraview.dataType -> pyraview.data_type). Only the *immediate*
 %       field names of each block are renamed; nested struct values
 %       (e.g., filter.parameters.sampleFrequency) are left alone for
-%       per-class migrators to handle if needed.
+%       per-class migrators to handle if needed. [gated by
+%       RenameClassNames]
 %     - rewrite depends_on entries to the V_delta (name,
 %       document_id) shape. Accepts v1 (name, id [, version]) and
 %       the earlier V_delta draft (name, value); precedence is
@@ -56,6 +69,7 @@ function postBody = universalRenames(preBody)
 
 arguments
     preBody (1,1) struct
+    options.RenameClassNames (1,1) logical = true
 end
 
 if ~isfield(preBody, 'document_class') ...
@@ -67,20 +81,23 @@ end
 
 postBody = preBody;
 
-v1ClassName = char(postBody.document_class.class_name);
-v2ClassName = snakeCase(v1ClassName);
-v2ClassName = v1ToVDeltaClassName(v2ClassName);
-postBody.document_class.class_name = v2ClassName;
-if ~strcmp(v1ClassName, v2ClassName) && isfield(postBody, v1ClassName)
-    postBody.(v2ClassName) = postBody.(v1ClassName);
-    postBody = rmfield(postBody, v1ClassName);
+if options.RenameClassNames
+    v1ClassName = char(postBody.document_class.class_name);
+    v2ClassName = snakeCase(v1ClassName);
+    v2ClassName = v1ToVDeltaClassName(v2ClassName);
+    postBody.document_class.class_name = v2ClassName;
+    if ~strcmp(v1ClassName, v2ClassName) && isfield(postBody, v1ClassName)
+        postBody.(v2ClassName) = postBody.(v1ClassName);
+        postBody = rmfield(postBody, v1ClassName);
+    end
 end
 
 if isfield(postBody.document_class, 'superclasses') ...
         && isstruct(postBody.document_class.superclasses) ...
         && ~isempty(postBody.document_class.superclasses)
     postBody.document_class.superclasses = ...
-        normaliseSuperclasses(postBody.document_class.superclasses);
+        normaliseSuperclasses(postBody.document_class.superclasses, ...
+            options.RenameClassNames);
 end
 
 if isfield(postBody, 'depends_on') ...
@@ -89,7 +106,9 @@ if isfield(postBody, 'depends_on') ...
     postBody.depends_on = renameDependsOnEntries(postBody.depends_on);
 end
 
-postBody = snakeCasePropertyBlocks(postBody);
+if options.RenameClassNames
+    postBody = snakeCasePropertyBlocks(postBody);
+end
 
 if isfield(postBody, 'ndi_document')
     if isfield(postBody, 'base')
@@ -165,6 +184,14 @@ end
 out = name;
 end
 
+function out = maybeSnakeCase(name, doRename)
+if doRename
+    out = snakeCase(name);
+else
+    out = name;
+end
+end
+
 function out = snakeCase(name)
 % Acronym-aware snake_case.
 %
@@ -212,13 +239,19 @@ end
 out = result;
 end
 
-function out = normaliseSuperclasses(sc)
+function out = normaliseSuperclasses(sc, renameClassNames)
 % Make sure each superclass entry has a class_name field, deriving it
 % from a v1 `definition` path (e.g., $NDIDOCUMENTPATH/data/filter.json
-% -> filter) when absent. snake_case any class_name found. Preserve
-% the entry's other fields (`definition`, `class_version`,
+% -> filter) when absent. When RENAMECLASSNAMES is true, snake_case
+% any class_name found; when false, leave class_name spellings as-is
+% (still derive from `definition` when class_name is absent — that
+% derivation is not a rename, just a normalisation). Preserve the
+% entry's other fields (`definition`, `class_version`,
 % `property_list_name`, ...) so did.database/validate_doc_vs_schema
 % can still walk the superclass chain via the path in `definition`.
+if nargin < 2
+    renameClassNames = true;
+end
 n = numel(sc);
 % Collect each entry with its derived/normalised class_name, then
 % rebuild a homogeneous struct array spanning the union of fields.
@@ -226,9 +259,10 @@ entries = cell(1, n);
 for k = 1:n
     entry = sc(k);
     if isfield(entry, 'class_name') && ~isempty(entry.class_name)
-        entry.class_name = snakeCase(char(entry.class_name));
+        entry.class_name = maybeSnakeCase(char(entry.class_name), renameClassNames);
     elseif isfield(entry, 'definition') && ~isempty(entry.definition)
-        entry.class_name = snakeCase(deriveClassNameFromDefinition(entry.definition));
+        entry.class_name = maybeSnakeCase( ...
+            deriveClassNameFromDefinition(entry.definition), renameClassNames);
     else
         entry.class_name = '';
     end

--- a/src/did/+did2/+convert/v1_to_v2.m
+++ b/src/did/+did2/+convert/v1_to_v2.m
@@ -60,6 +60,12 @@ function result = v1_to_v2(v1Bodies, options)
 %                      that resolve to documents already stored in
 %                      this DB (e.g. when ingesting an incremental
 %                      batch on top of a populated database).
+%     RenameClassNames (1,1 logical, default true) - forward to
+%                      did2.convert.universalRenames. Pass false on
+%                      read paths whose bodies still spell their
+%                      identifiers in the legacy (camelCase) form so
+%                      the body stays schema-compatible while still
+%                      gaining the V_delta shape transformations.
 %
 %   See also: did2.convert.universalRenames, did2.convert.migrators,
 %   docs/v2/PLAN.md §9.6.
@@ -71,6 +77,7 @@ arguments
     options.Verbose (1,1) logical = false
     options.CheckReferences (1,1) logical = false
     options.ReferenceDatabase = []
+    options.RenameClassNames (1,1) logical = true
 end
 
 bodies = normaliseInput(v1Bodies);
@@ -105,7 +112,8 @@ for k = 1:numel(bodies)
                 className = char(v2Body.document_class.class_name);
             end
         else
-            postUniversalBody = did2.convert.universalRenames(preBody);
+            postUniversalBody = did2.convert.universalRenames(preBody, ...
+                'RenameClassNames', options.RenameClassNames);
             className = char(postUniversalBody.document_class.class_name);
             v2Body = applySuperclassMigrators(postUniversalBody, className);
             migratorFcn = lookupMigrator(className);

--- a/tests/+did2/+unittest/testConvertV1ToV2.m
+++ b/tests/+did2/+unittest/testConvertV1ToV2.m
@@ -370,6 +370,117 @@ for k = 1:numel(result.migrated)
 end
 end
 
+function testUniversalRenamesRenameClassNamesFalsePreservesClassName(testCase)
+% When RenameClassNames=false the document_class.class_name and the
+% matching top-level property block key are left untouched. This is
+% the contract callers like NDI's applyReadNormalization rely on:
+% their on-disk schemas still spell classnames in camelCase
+% (e.g., demoNDI) and the legacy v1 validator compares the strings
+% by exact match.
+v1 = makeV1Skeleton('demoNDI');
+v1.demoNDI = struct('value', 5);
+out = did2.convert.universalRenames(v1, 'RenameClassNames', false);
+verifyEqual(testCase, out.document_class.class_name, 'demoNDI');
+verifyTrue(testCase, isfield(out, 'demoNDI'));
+verifyFalse(testCase, isfield(out, 'demo_ndi'));
+verifyEqual(testCase, out.demoNDI.value, 5);
+% schema_version stamping still runs — that's the V_delta shape
+% transformation the gate flip actually needs.
+verifyEqual(testCase, out.document_class.schema_version, 'V_delta');
+end
+
+function testUniversalRenamesRenameClassNamesFalsePreservesSuperclassNames(testCase)
+% Superclass entries that already carry a class_name keep its
+% spelling. Entries that only carry a v1 `definition` path still
+% have their class_name derived from the basename (that derivation
+% is not a rename — it just surfaces the name v1 stored under a
+% different key), but with no snake_case sweep applied.
+v1 = makeV1Skeleton('demoNDIMock');
+v1.demoNDIMock = struct();
+v1.document_class.superclasses = struct( ...
+    'class_name', {'base', 'mock', 'demoNDI'});
+out = did2.convert.universalRenames(v1, 'RenameClassNames', false);
+sc = out.document_class.superclasses;
+verifyEqual(testCase, numel(sc), 3);
+verifyEqual(testCase, sc(1).class_name, 'base');
+verifyEqual(testCase, sc(2).class_name, 'mock');
+verifyEqual(testCase, sc(3).class_name, 'demoNDI');
+end
+
+function testUniversalRenamesRenameClassNamesFalseDerivesSuperclassFromDefinition(testCase)
+% definition-derived superclass names are still produced (the
+% derivation is not a rename), but no snake_case sweep is applied
+% to the result.
+v1 = makeV1Skeleton('demoNDI');
+v1.demoNDI = struct();
+v1.document_class.superclasses = struct( ...
+    'definition', {'$NDIDOCUMENTPATH/base.json', ...
+                   '$NDIDOCUMENTPATH/data/demoNDIMock.json'});
+out = did2.convert.universalRenames(v1, 'RenameClassNames', false);
+sc = out.document_class.superclasses;
+verifyEqual(testCase, sc(1).class_name, 'base');
+verifyEqual(testCase, sc(2).class_name, 'demoNDIMock');
+end
+
+function testUniversalRenamesRenameClassNamesFalseSkipsBlockFieldRenames(testCase)
+% Field names inside a class property block are part of the
+% identifier sweep too: leaving them snake_cased while the schema
+% still declares them in camelCase would trip the field validator.
+% RenameClassNames=false preserves the camelCase field names.
+v1 = makeV1Skeleton('demoNDI');
+v1.demoNDI = struct('nativeRate', 20000, 'dataType', 'double');
+out = did2.convert.universalRenames(v1, 'RenameClassNames', false);
+verifyTrue(testCase, isfield(out.demoNDI, 'nativeRate'));
+verifyTrue(testCase, isfield(out.demoNDI, 'dataType'));
+verifyFalse(testCase, isfield(out.demoNDI, 'native_rate'));
+verifyFalse(testCase, isfield(out.demoNDI, 'data_type'));
+end
+
+function testUniversalRenamesRenameClassNamesFalseStillRewritesDependsOn(testCase)
+% depends_on rewrites are V_delta shape changes, not identifier
+% renames, so they still run under RenameClassNames=false.
+v1 = makeV1Skeleton('demoNDI');
+v1.demoNDI = struct();
+v1.depends_on = struct( ...
+    'name',    {'subject_id'}, ...
+    'id',      {'aabb1122ccdd3344_aaaa1111bbbb2222'}, ...
+    'version', {'1'});
+out = did2.convert.universalRenames(v1, 'RenameClassNames', false);
+verifyEqual(testCase, out.depends_on(1).document_id, ...
+    'aabb1122ccdd3344_aaaa1111bbbb2222');
+verifyFalse(testCase, isfield(out.depends_on, 'id'));
+verifyFalse(testCase, isfield(out.depends_on, 'version'));
+end
+
+function testUniversalRenamesRenameClassNamesFalseStillRewritesAppBlock(testCase)
+% app.name -> app.app_name is a V_delta field rename to match
+% V_delta's `app` schema declaration. It is not gated by
+% RenameClassNames (it's a fixed-target rename, not an identifier
+% sweep).
+v1 = makeV1Skeleton('demoNDI');
+v1.demoNDI = struct();
+v1.app = struct('name', 'ndi', 'version', '1.0.0');
+out = did2.convert.universalRenames(v1, 'RenameClassNames', false);
+verifyEqual(testCase, out.app.app_name, 'ndi');
+verifyEqual(testCase, out.app.app_version, '1.0.0');
+verifyFalse(testCase, isfield(out.app, 'name'));
+verifyFalse(testCase, isfield(out.app, 'version'));
+end
+
+function testV1ToV2RenameClassNamesFalseThreadsThrough(testCase)
+% The dispatcher option threads down to universalRenames, so a
+% caller that needs the legacy-name-preserving behaviour can pass
+% it at the top level.
+v1 = makeV1Skeleton('demoNDI');
+v1.demoNDI = struct('value', 5);
+result = did2.convert.v1_to_v2(v1, 'Validate', false, ...
+    'RenameClassNames', false);
+verifyEqual(testCase, result.summary.migrated_count, 1);
+doc = result.migrated{1};
+verifyEqual(testCase, doc.className(), 'demoNDI');
+verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_delta');
+end
+
 function testShortCircuitSkippedWhenSchemaVersionMissing(testCase)
 % A body that lacks document_class.schema_version takes the full
 % pipeline even when it has no v1-only underscore markers. Guards


### PR DESCRIPTION
## Summary
This change adds a `RenameClassNames` option to the v1-to-V_delta conversion pipeline that allows callers to preserve legacy camelCase identifier spellings while still applying V_delta shape transformations. This is needed for read paths where on-disk schemas still use camelCase naming conventions.

## Key Changes
- **universalRenames.m**: Added `RenameClassNames` parameter (default `true`) that gates the snake_case identifier sweep:
  - When `false`, preserves `document_class.class_name` and top-level property block keys in their original spelling
  - Preserves field names inside property blocks (e.g., `nativeRate` stays as-is instead of becoming `native_rate`)
  - Preserves superclass `class_name` spellings (though derivation from `definition` paths still occurs)
  - Still applies non-identifier transformations: schema_version stamping, depends_on rewriting, and app block field renames

- **v1_to_v2.m**: Added `RenameClassNames` parameter that threads through to `universalRenames`, allowing top-level callers to control the behavior

- **testConvertV1ToV2.m**: Added comprehensive test coverage for the new option:
  - Verifies class name preservation when `RenameClassNames=false`
  - Confirms superclass name handling (both explicit and derived from definition paths)
  - Validates that field names inside property blocks are preserved
  - Ensures V_delta shape transformations still run (depends_on, app block rewrites)
  - Tests that the option threads through the v1_to_v2 dispatcher

## Implementation Details
- The `maybeSnakeCase()` helper function conditionally applies snake_case transformation based on the flag
- Superclass normalization was refactored to accept the `renameClassNames` parameter while still deriving class names from definition paths unconditionally
- The change maintains backward compatibility with default behavior (full V_delta normalization)

https://claude.ai/code/session_01BpvUtPZGMDjVKEJkpvQekN