### PR TITLE
element_epoch migrator: fix v1 t0_t1 orientation to 2-by-N

### DIFF
--- a/src/did/+did2/+convert/+migrators/element_epoch.m
+++ b/src/did/+did2/+convert/+migrators/element_epoch.m
@@ -8,20 +8,33 @@ function v2Body = element_epoch(preBody)
 %       element_epoch.clocks(i).t0     - start time   (double)
 %       element_epoch.clocks(i).t1     - stop time    (double)
 %
-%   did_v1 had two equivalent shapes:
+%   did_v1 storage convention is documented in NDI's
+%   element_epoch_schema.json:
+%
+%       "type": "matrix",
+%       "parameters": [2, NaN],
+%       "Each column is for a different epoch clock type."
+%
+%   That is: a 2-by-N matrix where rows are [t0; t1] and columns are
+%   clocks. ndi.element.addepoch and ndi.element.oneepoch both write
+%   this shape (the numel==2 path in addepoch columnizes a single
+%   clock to a 2-by-1 column vector, preserving the convention).
 %
 %   Single-clock (common in PRED, 20211116, B corpora):
 %       epoch_clock = 'dev_local_time'
-%       t0_t1       = [0  930.34795]
+%       t0_t1       = [0; 930.34795]            (2-by-1, or [0 930.34795])
 %
-%   Multi-clock (seen in the JH corpus):
+%   Multi-clock (e.g., the JH corpus, NDI mock):
 %       epoch_clock = 'dev_local_time,exp_global_time'
-%       t0_t1       = [0           738553.4082;
-%                      3599.69855  738553.4498]
+%       t0_t1       = [0          738553.4082;
+%                      3599.69855 738553.4498]   (2-by-N, columns=clocks)
+%     -> clocks(1) = (dev_local_time, t0=0,           t1=3599.69855)
+%        clocks(2) = (exp_global_time, t0=738553.4082, t1=738553.4498)
 %
-%   This migrator handles both. epoch_clock is comma-split into N
-%   names; t0_t1 is parsed as either an N-by-2 array or a 2-vector
-%   (which is the degenerate N=1 case).
+%   A length-2 row/column vector is treated as a degenerate single-clock
+%   case. A genuine N-by-2 matrix (rows=clocks, with N>=3 so the shape
+%   is unambiguous) is accepted as a defensive fallback in case any
+%   pre-canonical corpus stored that transpose.
 %
 %   A legacy `clocktype` v1 spelling (matching the epochclocktimes
 %   superclass naming) is also accepted defensively and renamed.
@@ -74,23 +87,37 @@ end
 end
 
 function pairs = parseT0T1Matrix(block, nClocks)
-% Always returns an N-by-2 numeric matrix. Padded with zeros if the
-% v1 doc had fewer rows than the clock-name count (defensive).
+% Returns an N-by-2 numeric matrix where row k is clock k's [t0, t1],
+% the format buildClockRecords consumes.
+%
+% Canonical did_v1 storage is 2-by-N (rows = [t0; t1], columns =
+% clocks) per NDI element_epoch_schema.json. A length-2 row/column
+% vector is the degenerate single-clock case. A genuine N-by-2
+% matrix (N >= 3) is accepted defensively in case any corpus stored
+% the transpose; for N = 2 the canonical 2-by-N branch matches
+% first, which is the unambiguous interpretation matching what
+% ndi.element.addepoch / oneepoch actually write.
 if ~isfield(block, 't0_t1')
     pairs = zeros(nClocks, 2);
     return;
 end
 raw = block.t0_t1;
-if isnumeric(raw) && isvector(raw) && numel(raw) == 2
+if ~isnumeric(raw)
+    pairs = zeros(nClocks, 2);
+    return;
+end
+if isvector(raw) && numel(raw) == 2
+    % Single-clock degenerate: [t0 t1] (row) or [t0; t1] (column).
     pairs = double(reshape(raw, 1, 2));
-elseif isnumeric(raw) && size(raw, 2) == 2
+elseif size(raw, 1) == 2 && size(raw, 2) >= 1
+    % Canonical 2-by-N: rows = [t0; t1], columns = clocks.
+    pairs = double(raw.');
+elseif size(raw, 2) == 2
+    % Defensive: N-by-2 (N >= 3) where each row is a clock's [t0 t1].
     pairs = double(raw);
-elseif isnumeric(raw) && size(raw, 1) == 2 && size(raw, 2) >= 1
-    % v1 occasionally ships the transpose; accept it.
-    pairs = double(raw');
 else
     pairs = zeros(nClocks, 2);
-    if isnumeric(raw) && numel(raw) >= 1
+    if numel(raw) >= 1
         pairs(1, 1) = double(raw(1));
         if numel(raw) >= 2
             pairs(1, 2) = double(raw(2));

--- a/tests/+did2/+unittest/testMigrators.m
+++ b/tests/+did2/+unittest/testMigrators.m
@@ -390,7 +390,11 @@ verifyFalse(testCase, isfield(out.element_epoch, 'epoch_clock'));
 end
 
 function testElementEpochMultiClockBuildsArrayOfRecords(testCase)
-% JH corpus case: epoch_clock is comma-separated, t0_t1 is N-by-2.
+% Multi-clock case: epoch_clock is comma-separated, t0_t1 is the
+% canonical 2-by-N (per NDI element_epoch_schema.json:
+% "parameters":[2,NaN], "Each column is for a different epoch clock
+% type"). This is what ndi.element.addepoch and oneepoch actually
+% write.
 v1 = wrap('element_epoch', 'element_epoch', struct( ...
     'epoch_clock', 'dev_local_time,exp_global_time', ...
     't0_t1',       [0           738553.4082; ...
@@ -400,9 +404,9 @@ out = did2.convert.migrators.element_epoch( ...
 verifyEqual(testCase, numel(out.element_epoch.clocks), 2);
 verifyEqual(testCase, out.element_epoch.clocks(1).name, 'dev_local_time');
 verifyEqual(testCase, out.element_epoch.clocks(1).t0, 0);
-verifyEqual(testCase, out.element_epoch.clocks(1).t1, 738553.4082);
+verifyEqual(testCase, out.element_epoch.clocks(1).t1, 3599.69855);
 verifyEqual(testCase, out.element_epoch.clocks(2).name, 'exp_global_time');
-verifyEqual(testCase, out.element_epoch.clocks(2).t0, 3599.69855);
+verifyEqual(testCase, out.element_epoch.clocks(2).t0, 738553.4082);
 verifyEqual(testCase, out.element_epoch.clocks(2).t1, 738553.4498);
 end
 


### PR DESCRIPTION
## Summary

`parseT0T1Matrix` in the `element_epoch` migrator was reading legacy `element_epoch.t0_t1` as **N-by-2** (rows = clocks, cols = `[t0, t1]`). That disagrees with the actual NDI storage convention, which `ndi_common/schema_documents/element_epoch_schema.json` documents as:

```json
"type": "matrix",
"parameters": [2, NaN],
"documentation": "Each column is for a different epoch clock type."
```

i.e. **2-by-N** (rows = `[t0; t1]`, cols = clocks). Both `ndi.element.addepoch` (the `numel==2` path columnizes single-clock to a `2-by-1` column vector) and `ndi.element.oneepoch` write this shape; the NDI tuningcurve mock (`ndi.mock.fun.stimulus_response`) does too.

For a 2-by-2 multi-clock matrix the prior code's `size(raw,2)==2` branch matched first and skipped the transpose. Result: `clocks(k).t0 == clocks(k).t1` (both pulled from the same row). That collapsed every multi-clock epoch's `t0_t1` in V_delta, which made the syncgraph `time_convert` affine map degenerate to `t_in - epoch_end` (rather than the intended same-epoch identity). So UTC stim onsets landed outside the `dev_local_time` window of the spike data and every tuning-curve response computed to zero — observed downstream as NDI-matlab `testCalcTuningCurve` failing with `b == zeros(4)` once the read-side V_delta gate was flipped on for the 776 branch.

## Changes

- `src/did/+did2/+convert/+migrators/element_epoch.m`: rewrite `parseT0T1Matrix` so 2-by-N is the canonical legacy shape (transpose to N-by-2 before `buildClockRecords`). Length-2 vectors stay the degenerate single-clock case; a genuine N-by-2 matrix (only reachable for N >= 3, since `size(raw,1)==2` catches everything else) is kept as a defensive fallback for any pre-canonical corpus. Header docstring updated to cite the NDI schema and the actual NDI writer convention.
- `tests/+did2/+unittest/testMigrators.m`: same `[0 738553.4082; 3599.69855 738553.4498]` input matrix; expected outputs swapped to the corrected interpretation. With clock list `'dev_local_time,exp_global_time'`:
  - `clocks(1) = (dev_local_time, t0=0, t1=3599.69855)`  — ~1h local recording
  - `clocks(2) = (exp_global_time, t0=738553.4082, t1=738553.4498)` — windowed in global time

The previous test expectations agreed with the buggy migrator but disagreed with the schema (placed a 1-hour `t1` value on a global-time clock and a 738553-second `t0` on a local clock).

## Test plan

- [ ] `runtests('did2.unittest.testMigrators')` passes locally (including the swapped multi-clock case).
- [ ] `runtests('did2.unittest.testCorpusJH')` — discovery-mode end-to-end run against the JH corpus is unaffected (already discovery-mode, doesn't assert specific values).
- [ ] After merge to V2: NDI-matlab `testCalcTuningCurve` on `claude/776-flip-did2-normalize-gate` returns `diag([1 1 1 1])` for both `b` and `b_expected`. Will follow up by cleaning the NDI-matlab diagnostic dumps once green.

## Background

Tracking issue: VH-Lab/NDI-matlab#776 (flip did2 read-normalization gate to V_delta).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpvUtPZGMDjVKEJkpvQekN)_