### PR TITLE
schema cache: per-field `placement` (declaring_class / concrete_class)

### DIFF
--- a/src/did/+did2/+convert/calcCommon.m
+++ b/src/did/+did2/+convert/calcCommon.m
@@ -3,11 +3,24 @@ function v2Body = calcCommon(preBody, v1ClassName)
 %
 %   v2Body = did2.convert.calcCommon(PREBODY, V1CLASSNAME) reshapes a
 %   did_v1 calculator document body to match the V_delta
-%   `calculator`-base inheritance: the v1 `<class>.input_parameters`
-%   field is moved into a new top-level `calculator` block, the
-%   value is coerced to a struct (v1 frequently ships an empty
-%   array), and v1-only fields on the concrete class block that
-%   V_delta does not declare are dropped.
+%   `calculator`-base inheritance contract. The abstract
+%   `calculator` parent declares `input_parameters` with
+%   `placement: "concrete_class"` (DID-schema V_delta calculator.json),
+%   which means the field is hosted on the concrete subclass's block
+%   (`<v1ClassName>.input_parameters`) on V_delta instance bodies and
+%   the abstract `calculator` class contributes no body block. See
+%   V_gamma_SPEC.md "Field placement" under "Field Definition Object".
+%
+%   v1 already stores `input_parameters` on the concrete class block
+%   (`<class>.input_parameters`) — the same location V_delta wants —
+%   so no structural move is needed. This migrator therefore only:
+%
+%     1. Coerces `<class>.input_parameters` to a struct (v1 sometimes
+%        shipped an empty `[]`; V_delta wants `struct()`). Idempotent
+%        for v1 bodies that already shipped a struct.
+%     2. Drops a redundant inner `depends_on` if v1 stored one on the
+%        calc block (e.g., `oridirtuning_calc.depends_on`); V_delta
+%        only honors top-level `depends_on`.
 %
 %   The calculator-identity string lives in `app.app_name`, not in a
 %   `calculator.calculator_name` field; that rename is handled
@@ -26,7 +39,10 @@ function v2Body = calcCommon(preBody, v1ClassName)
 %   The dispatcher's downstream ensureClassBlocks pass adds empty
 %   `{}` property blocks for the rest of the V_delta inheritance
 %   chain (e.g., `tuning_fit`, the measurement parent), so this
-%   helper does not need to manufacture them.
+%   helper does not need to manufacture them. ensureClassBlocks is
+%   placement-aware and will not manufacture a `calculator` block
+%   since calculator contributes nothing of its own to instance
+%   bodies under the placement contract.
 %
 %   See did-schema's schemas/V_delta/conversions/from_did_v1/
 %   oridirtuning_calc.md for the full conversion spec.
@@ -46,12 +62,10 @@ end
 block = v2Body.(v1ClassName);
 
 if isfield(block, 'input_parameters')
-    inputParams = block.input_parameters;
-    block = rmfield(block, 'input_parameters');
+    block.input_parameters = coerceToStruct(block.input_parameters);
 else
-    inputParams = struct();
+    block.input_parameters = struct();
 end
-inputParams = coerceToStruct(inputParams);
 
 % v1 sometimes stored an internal `depends_on` struct on the calc
 % block (e.g., oridirtuning_calc.depends_on); V_delta only honors
@@ -61,8 +75,6 @@ if isfield(block, 'depends_on')
 end
 
 v2Body.(v1ClassName) = block;
-
-v2Body.calculator = struct('input_parameters', inputParams);
 end
 
 function out = coerceToStruct(value)

--- a/src/did/+did2/+convert/v1_to_v2.m
+++ b/src/did/+did2/+convert/v1_to_v2.m
@@ -285,13 +285,18 @@ if isempty(cache)
     return;
 end
 try
-    chain = cache.classChain(className);
+    placementInfo = cache.resolvePlacement(className);
     ancestors = cache.superclasses(className);
 catch
     return;
 end
-for k = 1:numel(chain)
-    cls = chain{k};
+% Placement-aware: only classes that contribute a body block (per
+% V_gamma_SPEC.md "Field placement") get an empty struct manufactured
+% for them. An abstract class whose declared fields are all
+% `placement: "concrete_class"` (e.g., `calculator`) does NOT
+% materialize on the instance body.
+for k = 1:numel(placementInfo.blocksContributed)
+    cls = placementInfo.blocksContributed{k};
     if ~isfield(body, cls)
         body.(cls) = struct();
     end

--- a/src/did/+did2/+schema/cache.m
+++ b/src/did/+did2/+schema/cache.m
@@ -42,6 +42,8 @@ classdef cache < handle
     %       ownFields           - the `fields` list a class declares directly.
     %       fieldsFor           - merged inherited fields tagged with the
     %                             declaring class (struct array).
+    %       resolvePlacement    - per-block field layout for a concrete class,
+    %                             honoring per-field `placement`.
     %       loadAllSchemas      - parse every *.json in the schema dir.
     %       queryablePaths      - scalar and array-iteration paths
     %                             declared by the loaded schemas.
@@ -181,6 +183,147 @@ classdef cache < handle
                         'fieldDef', own{f}); %#ok<AGROW>
                 end
             end
+        end
+
+        function info = resolvePlacement(obj, className)
+            % resolvePlacement - per-block field layout for a concrete
+            %   class, honoring the per-field `placement` attribute
+            %   (V_gamma_SPEC.md "Field placement"). For each field
+            %   declared anywhere in the class chain, decides which
+            %   property block hosts the field on instance bodies:
+            %
+            %     placement = "declaring_class" (default)
+            %       -> hosted on the declaring class's block.
+            %     placement = "concrete_class"
+            %       -> hosted on the concrete (leaf) class's block.
+            %         Only valid on fields declared by an abstract
+            %         class.
+            %
+            %   Returns a struct with three fields:
+            %
+            %     info.blocksContributed
+            %       cellstr of block names (each a class name in the
+            %       chain) that contribute a property block on instance
+            %       bodies. A concrete class always contributes. An
+            %       abstract class contributes only if at least one of
+            %       its own fields uses placement="declaring_class".
+            %
+            %     info.fieldsByBlock
+            %       containers.Map keyed by block name; each value is a
+            %       struct array with fields:
+            %         .fieldDef        the raw schema field entry
+            %         .declaringClass  the class that declared it
+            %         .placement       'declaring_class' | 'concrete_class'
+            %
+            %     info.chain
+            %       cellstr root-first class chain (same as classChain).
+            %
+            %   Raises did2:schema:* on:
+            %     placementOnConcreteClass  field with placement="concrete_class"
+            %                               declared by a non-abstract class.
+            %     invalidPlacement          placement value other than the two
+            %                               allowed strings.
+            %     placementCollision        same field name lands twice in the
+            %                               same block (either two ancestors
+            %                               both place into the concrete-class
+            %                               block, or any class redeclares a
+            %                               name an ancestor has placed).
+            arguments
+                obj
+                className (1,:) char
+            end
+
+            chain = obj.classChain(className);
+            leaf  = className;
+
+            entriesByBlock = containers.Map();
+            blocksContributedSet = containers.Map();
+
+            for k = 1:numel(chain)
+                cls = chain{k};
+                clsSchema = obj.getClass(cls);
+                isAbstract = obj.classIsAbstract(clsSchema);
+                own = obj.ownFields(cls);
+
+                clsContributesOwnBlock = ~isAbstract;
+                for f = 1:numel(own)
+                    fdef = own{f};
+                    fieldName = char(fdef.name);
+                    placement = obj.fieldPlacement(fdef);
+
+                    if strcmp(placement, 'concrete_class')
+                        if ~isAbstract
+                            error('did2:schema:placementOnConcreteClass', ...
+                                ['Field "%s" on class "%s" sets ', ...
+                                 'placement="concrete_class" but "%s" is ', ...
+                                 'not abstract. placement="concrete_class" ', ...
+                                 'is only valid on fields declared by ', ...
+                                 'abstract classes (V_gamma_SPEC.md ', ...
+                                 '"Field placement").'], ...
+                                fieldName, cls, cls);
+                        end
+                        targetBlock = leaf;
+                    elseif strcmp(placement, 'declaring_class')
+                        targetBlock = cls;
+                        clsContributesOwnBlock = true;
+                    else
+                        error('did2:schema:invalidPlacement', ...
+                            ['Field "%s" on class "%s" has invalid ', ...
+                             'placement value "%s". Allowed values are ', ...
+                             '"declaring_class" and "concrete_class".'], ...
+                            fieldName, cls, placement);
+                    end
+
+                    entry = struct( ...
+                        'fieldDef',       fdef, ...
+                        'declaringClass', cls, ...
+                        'placement',      placement);
+
+                    if isKey(entriesByBlock, targetBlock)
+                        existing = entriesByBlock(targetBlock);
+                        for j = 1:numel(existing)
+                            if strcmp(existing(j).fieldDef.name, fieldName)
+                                error('did2:schema:placementCollision', ...
+                                    ['Field name "%s" collides in ', ...
+                                     'block "%s" of class chain for ', ...
+                                     '"%s": declared by "%s" ', ...
+                                     '(placement="%s") and "%s" ', ...
+                                     '(placement="%s"). No class in ', ...
+                                     'the chain may declare a field ', ...
+                                     'whose name matches a ', ...
+                                     'placement="concrete_class" ', ...
+                                     'declaration on any ancestor ', ...
+                                     '(V_gamma_SPEC.md "Field placement").'], ...
+                                    fieldName, targetBlock, leaf, ...
+                                    existing(j).declaringClass, ...
+                                    existing(j).placement, ...
+                                    cls, placement);
+                            end
+                        end
+                        existing(end+1) = entry; %#ok<AGROW>
+                        entriesByBlock(targetBlock) = existing;
+                    else
+                        entriesByBlock(targetBlock) = entry;
+                    end
+                end
+
+                if clsContributesOwnBlock
+                    blocksContributedSet(cls) = true;
+                end
+            end
+
+            % Preserve root-first chain order for blocksContributed.
+            blocksContributed = {};
+            for k = 1:numel(chain)
+                if isKey(blocksContributedSet, chain{k})
+                    blocksContributed{end+1} = chain{k}; %#ok<AGROW>
+                end
+            end
+
+            info = struct();
+            info.blocksContributed = blocksContributed;
+            info.fieldsByBlock     = entriesByBlock;
+            info.chain             = chain;
         end
 
         function loadAllSchemas(obj)
@@ -347,10 +490,16 @@ classdef cache < handle
 
             doc.depends_on = struct('name', {}, 'document_id', {});
 
-            chain = obj.classChain(className);
-            for k = 1:numel(chain)
-                blockClass = chain{k};
-                doc.(blockClass) = obj.buildBlockForClass(blockClass);
+            % Placement-aware block layout: only contributing blocks
+            % appear on the body, each populated with the fields routed
+            % to it (the class's own declaring-class fields plus any
+            % concrete-class-placed fields from abstract ancestors when
+            % this is the leaf).
+            info = obj.resolvePlacement(className);
+            for k = 1:numel(info.blocksContributed)
+                blockClass = info.blocksContributed{k};
+                doc.(blockClass) = obj.buildBlockFromEntries( ...
+                    blockClass, info.fieldsByBlock);
             end
         end
 
@@ -418,9 +567,14 @@ classdef cache < handle
                     strjoin(declaredAncestors, ', '), ...
                     strjoin(expectedAncestors, ', '));
             end
-            chain = obj.classChain(className);
-            for k = 1:numel(chain)
-                blockClass = chain{k};
+            % Placement-aware: a class in the chain whose declared
+            % fields are all `placement: "concrete_class"` does not
+            % contribute a body block. Inherited fields routed onto the
+            % concrete leaf's block are validated there against their
+            % declaring class's field definition.
+            info = obj.resolvePlacement(className);
+            for k = 1:numel(info.blocksContributed)
+                blockClass = info.blocksContributed{k};
                 if ~isfield(s, blockClass)
                     error('did2:validation:missingClassBlock', ...
                         'Document is missing the "%s" property block.', blockClass);
@@ -431,19 +585,24 @@ classdef cache < handle
                         'Property block "%s" must be a struct, got %s.', ...
                         blockClass, class(block));
                 end
-                own = obj.ownFields(blockClass);
-                declaredNames = cell(1, numel(own));
-                for f = 1:numel(own)
-                    fieldDef = own{f};
+                if isKey(info.fieldsByBlock, blockClass)
+                    entries = info.fieldsByBlock(blockClass);
+                else
+                    entries = struct('fieldDef', {}, 'declaringClass', {}, 'placement', {});
+                end
+                declaredNames = cell(1, numel(entries));
+                for f = 1:numel(entries)
+                    fieldDef = entries(f).fieldDef;
                     fieldName = char(fieldDef.name);
                     declaredNames{f} = fieldName;
                     obj.validateField(block, fieldDef, blockClass, fieldName);
                 end
                 % Strict-fields check: every property-block field must be
-                % declared by the class schema. Anything else is mis-keyed
-                % data (e.g., a v1 field name the migrator forgot to map)
-                % or a v1-only field that needs an explicit drop. Loud
-                % failure beats silent passthrough.
+                % declared by the (placement-resolved) schema layout for
+                % this block. Anything else is mis-keyed data (e.g., a
+                % v1 field name the migrator forgot to map) or a v1-only
+                % field that needs an explicit drop. Loud failure beats
+                % silent passthrough.
                 blockFns = fieldnames(block);
                 for fk = 1:numel(blockFns)
                     fn = blockFns{fk};
@@ -459,11 +618,13 @@ classdef cache < handle
                 end
             end
             % Strict top-level check: every top-level key must be either
-            % a structural key, a chain block, or the optional file/files
-            % wrapper. Anything else is a v1 block whose key did not get
-            % snake-cased (e.g., `imageStack_parameters` should become
-            % `image_stack_parameters`) or a class not modelled by V_delta.
-            allowedTop = [chain, {'document_class', 'depends_on', 'file', 'files'}];
+            % a structural key, a contributing chain block, or the
+            % optional file/files wrapper. A chain class that does not
+            % contribute a body block (all of its declared fields placed
+            % at concrete_class) appearing as a top-level key on the
+            % body is treated as an undeclared block — the abstract
+            % class has no fields of its own to host on the instance.
+            allowedTop = [info.blocksContributed, {'document_class', 'depends_on', 'file', 'files'}];
             topFns = fieldnames(s);
             for tk = 1:numel(topFns)
                 tn = topFns{tk};
@@ -637,26 +798,30 @@ classdef cache < handle
             end
         end
 
-        function block = buildBlockForClass(obj, className)
-            % buildBlockForClass - one property block populated with
-            %   `blank_value` for every field the class declares
-            %   directly. Base block also receives a fresh did_uid for
-            %   `id` and the current UTC timestamp for `datestamp`.
+        function block = buildBlockFromEntries(obj, blockClass, fieldsByBlock)
+            % buildBlockFromEntries - populate one property block from
+            %   the placement-resolved field entries for `blockClass`
+            %   (from resolvePlacement(.).fieldsByBlock). Honors
+            %   `blank_value` per field. Base block also receives a
+            %   fresh did_uid for `id` and a UTC timestamp for
+            %   `datestamp`.
             block = struct();
-            own = obj.ownFields(className);
-            for f = 1:numel(own)
-                fieldDef = own{f};
-                fieldName = char(fieldDef.name);
-                blank = fieldDef.blank_value;
-                fieldType = char(fieldDef.type);
-                if strcmp(fieldType, 'structure') ...
-                        && (isempty(blank) || (isstruct(blank) && isempty(fieldnames(blank))))
-                    block.(fieldName) = obj.buildBlankStructure(fieldDef);
-                else
-                    block.(fieldName) = blank;
+            if isKey(fieldsByBlock, blockClass)
+                entries = fieldsByBlock(blockClass);
+                for f = 1:numel(entries)
+                    fieldDef = entries(f).fieldDef;
+                    fieldName = char(fieldDef.name);
+                    blank = fieldDef.blank_value;
+                    fieldType = char(fieldDef.type);
+                    if strcmp(fieldType, 'structure') ...
+                            && (isempty(blank) || (isstruct(blank) && isempty(fieldnames(blank))))
+                        block.(fieldName) = obj.buildBlankStructure(fieldDef);
+                    else
+                        block.(fieldName) = blank;
+                    end
                 end
             end
-            if strcmp(className, 'base')
+            if strcmp(blockClass, 'base')
                 if isfield(block, 'id')
                     block.id = did.ido.unique_id();
                 end
@@ -848,6 +1013,37 @@ classdef cache < handle
                         % `pattern` and similar can be added later.
                 end
             end
+        end
+
+        function tf = classIsAbstract(~, classSchema)
+            % classIsAbstract - true if the document_class header carries
+            %   `abstract: true`.
+            tf = false;
+            if ~isstruct(classSchema) || ~isfield(classSchema, 'document_class')
+                return;
+            end
+            dc = classSchema.document_class;
+            if ~isstruct(dc) || ~isfield(dc, 'abstract')
+                return;
+            end
+            abstractVal = dc.abstract;
+            tf = (islogical(abstractVal) && abstractVal) ...
+                || (isnumeric(abstractVal) && abstractVal == 1);
+        end
+
+        function placement = fieldPlacement(~, fieldDef)
+            % fieldPlacement - return the field's `placement` value,
+            %   defaulting to 'declaring_class' when the key is absent
+            %   or empty.
+            placement = 'declaring_class';
+            if ~isstruct(fieldDef) || ~isfield(fieldDef, 'placement')
+                return;
+            end
+            raw = fieldDef.placement;
+            if isempty(raw)
+                return;
+            end
+            placement = char(raw);
         end
     end
 end

--- a/tests/+did2/+unittest/testMigrators.m
+++ b/tests/+did2/+unittest/testMigrators.m
@@ -236,27 +236,31 @@ end
 
 % --- calc-base migrators (PLAN.md §9.6 sub-step 6d, 20211116 corpus) ---
 
-function testCalcCommonMovesInputParametersIntoCalculatorBlock(testCase)
+function testCalcCommonKeepsInputParametersOnSubclassBlock(testCase)
+% V_delta `calculator.input_parameters` declares `placement:
+% "concrete_class"` (DID-schema V_delta calculator.json), so the
+% field lives on the concrete subclass's block on instance bodies,
+% not in a `calculator` block. v1 already stores it there, so no
+% structural move is required.
 v1 = wrap('oridirtuning_calc', 'oridirtuning_calc', struct( ...
     'input_parameters', struct('algorithm', 'best')));
 out = did2.convert.calcCommon( ...
     did2.convert.universalRenames(v1), 'oridirtuning_calc');
-verifyEqual(testCase, out.calculator.input_parameters.algorithm, 'best');
-verifyFalse(testCase, isfield(out.oridirtuning_calc, 'input_parameters'));
-% calcCommon does not populate calculator-identity; that lives on
-% the inherited app block, handled by universalRenames upstream.
-verifyFalse(testCase, isfield(out.calculator, 'calculator_name'));
+verifyEqual(testCase, out.oridirtuning_calc.input_parameters.algorithm, 'best');
+verifyFalse(testCase, isfield(out, 'calculator'));
 end
 
 function testCalcCommonCoercesEmptyArrayInputParametersToStruct(testCase)
 % v1 frequently ships `input_parameters: []`. V_delta `structure`
-% type requires a struct value, so the helper coerces.
+% type requires a struct value, so the helper coerces in place on
+% the subclass block.
 v1 = wrap('oridirtuning_calc', 'oridirtuning_calc', struct( ...
     'input_parameters', []));
 out = did2.convert.calcCommon( ...
     did2.convert.universalRenames(v1), 'oridirtuning_calc');
-verifyTrue(testCase, isstruct(out.calculator.input_parameters));
-verifyTrue(testCase, isempty(fieldnames(out.calculator.input_parameters)));
+verifyTrue(testCase, isstruct(out.oridirtuning_calc.input_parameters));
+verifyTrue(testCase, isempty(fieldnames(out.oridirtuning_calc.input_parameters)));
+verifyFalse(testCase, isfield(out, 'calculator'));
 end
 
 function testCalcCommonDropsInnerDependsOn(testCase)
@@ -280,14 +284,15 @@ end
 
 function testCalcWrapperPipesThroughHelper(testCase)
 % Each per-class wrapper is a thin call to calcCommon; verify the
-% wrapper produces the same shape (input_parameters lifted into
-% calculator block) as a direct calcCommon call.
+% wrapper produces the same shape (input_parameters preserved on
+% the subclass block, no calculator block) as a direct calcCommon
+% call.
 v1 = wrap('oridirtuning_calc', 'oridirtuning_calc', struct( ...
     'input_parameters', []));
 out = did2.convert.migrators.oridirtuning_calc( ...
     did2.convert.universalRenames(v1));
-verifyTrue(testCase, isstruct(out.calculator.input_parameters));
-verifyFalse(testCase, isfield(out.oridirtuning_calc, 'input_parameters'));
+verifyTrue(testCase, isstruct(out.oridirtuning_calc.input_parameters));
+verifyFalse(testCase, isfield(out, 'calculator'));
 end
 
 function testCalcMigratorWrappersAllResolve(testCase)
@@ -312,8 +317,10 @@ for k = 1:numel(classes)
     v1 = wrap(cls, cls, struct('input_parameters', []));
     migratorFcn = str2func(['did2.convert.migrators.' cls]);
     out = migratorFcn(did2.convert.universalRenames(v1));
-    verifyTrue(testCase, isstruct(out.calculator.input_parameters), ...
-        sprintf('Wrapper %s did not produce a calculator block', cls));
+    verifyTrue(testCase, isstruct(out.(cls).input_parameters), ...
+        sprintf('Wrapper %s did not produce input_parameters on the subclass block', cls));
+    verifyFalse(testCase, isfield(out, 'calculator'), ...
+        sprintf('Wrapper %s synthesized a phantom calculator block', cls));
 end
 end
 
@@ -356,21 +363,24 @@ end
 
 function testDispatcherPadsEmptyChainBlocks(testCase)
 % ensureClassBlocks should manufacture empty blocks for every class
-% in the V_delta chain that the migrator did not produce. This test
-% asserts the behavior without requiring a real schema cache: it
-% builds a body, lets the dispatcher run (Validate=false, no
-% SchemaCache override). The helper silently no-ops when no cache
-% is configured, so we only assert that the explicitly-produced
-% blocks survive.
+% in the V_delta chain that the migrator did not produce AND that
+% contributes a body block (i.e., not an abstract class with all
+% placement="concrete_class" fields). This test asserts the behavior
+% without requiring a real schema cache: it builds a body, lets the
+% dispatcher run (Validate=false, no SchemaCache override). The
+% helper silently no-ops when no cache is configured, so we only
+% assert that calcCommon's explicit work survives.
 v1 = wrap('oridirtuning_calc', 'oridirtuning_calc', struct( ...
     'input_parameters', []));
 result = did2.convert.v1_to_v2(v1, 'Validate', false);
 verifyEqual(testCase, result.summary.migrated_count, 1);
 doc = result.migrated{1};
-% calcCommon produced a calculator block with input_parameters
-% coerced to struct; calculator-identity is now app.app_name (set
-% by universalRenames) and is absent from the calculator block.
-verifyTrue(testCase, isstruct(doc.get('calculator.input_parameters')));
+% calcCommon coerces input_parameters to a struct in place on the
+% concrete subclass block; per V_delta calculator.input_parameters
+% placement="concrete_class", the abstract `calculator` class
+% contributes no body block. Calculator-identity is on app.app_name
+% (set by universalRenames).
+verifyTrue(testCase, isstruct(doc.get('oridirtuning_calc.input_parameters')));
 end
 
 % --- element_epoch (20211116 corpus: 252 docs; JH corpus: 4156 multi-clock) ---

--- a/tests/+did2/+unittest/testSchemaCache.m
+++ b/tests/+did2/+unittest/testSchemaCache.m
@@ -407,3 +407,123 @@ cache.loadAllSchemas();
 n2 = numel(cache.queryablePaths().scalar);
 verifyEqual(testCase, n1, n2);
 end
+
+% ---- resolvePlacement (V_gamma_SPEC.md "Field placement") ----
+
+function testResolvePlacementDefaultsToDeclaringClass(testCase)
+% demoB extends base with one own field; no fixture uses placement,
+% so every field is declaring_class-placed and every chain class
+% contributes a body block.
+cache = testCase.TestData.cache;
+info = cache.resolvePlacement('demoB');
+verifyEqual(testCase, info.chain, {'base', 'demoA', 'demoB'});
+% All three classes contribute body blocks under default placement.
+verifyEqual(testCase, sort(info.blocksContributed), sort({'base', 'demoA', 'demoB'}));
+% Each field lands in its declaring class's block.
+baseEntries  = info.fieldsByBlock('base');
+demoAEntries = info.fieldsByBlock('demoA');
+verifyTrue(testCase, all(strcmp({baseEntries.declaringClass}, 'base')));
+verifyTrue(testCase, all(strcmp({demoAEntries.declaringClass}, 'demoA')));
+verifyTrue(testCase, all(strcmp({baseEntries.placement}, 'declaring_class')));
+end
+
+function testResolvePlacementRoutesAbstractFieldOntoConcreteBlock(testCase)
+% demoAbstractPlacement (abstract) declares shared_field with
+% placement=concrete_class; demoPlaceConcrete extends it and adds
+% own_field. Both fields should land in demoPlaceConcrete's block,
+% and demoAbstractPlacement should not contribute a block.
+cache = testCase.TestData.cache;
+info = cache.resolvePlacement('demoPlaceConcrete');
+verifyTrue(testCase, any(strcmp(info.blocksContributed, 'demoPlaceConcrete')));
+verifyTrue(testCase, any(strcmp(info.blocksContributed, 'base')));
+verifyFalse(testCase, any(strcmp(info.blocksContributed, 'demoAbstractPlacement')));
+entries = info.fieldsByBlock('demoPlaceConcrete');
+fieldNames = arrayfun(@(e) char(e.fieldDef.name), entries, 'UniformOutput', false);
+declarings  = {entries.declaringClass};
+placements  = {entries.placement};
+verifyTrue(testCase, any(strcmp(fieldNames, 'shared_field')));
+verifyTrue(testCase, any(strcmp(fieldNames, 'own_field')));
+sharedIdx = find(strcmp(fieldNames, 'shared_field'), 1);
+ownIdx    = find(strcmp(fieldNames, 'own_field'),    1);
+verifyEqual(testCase, declarings{sharedIdx}, 'demoAbstractPlacement');
+verifyEqual(testCase, placements{sharedIdx}, 'concrete_class');
+verifyEqual(testCase, declarings{ownIdx},    'demoPlaceConcrete');
+verifyEqual(testCase, placements{ownIdx},    'declaring_class');
+end
+
+function testResolvePlacementMixedAbstractStillContributesBlock(testCase)
+% demoMixedPlacement (abstract) has one declaring_class field
+% (stays_on_parent) and one concrete_class field (moves_to_child).
+% It must still contribute a body block holding stays_on_parent.
+% moves_to_child lands on the concrete demoMixedConcrete block.
+cache = testCase.TestData.cache;
+info = cache.resolvePlacement('demoMixedConcrete');
+verifyTrue(testCase, any(strcmp(info.blocksContributed, 'demoMixedPlacement')));
+verifyTrue(testCase, any(strcmp(info.blocksContributed, 'demoMixedConcrete')));
+parentEntries = info.fieldsByBlock('demoMixedPlacement');
+childEntries  = info.fieldsByBlock('demoMixedConcrete');
+parentFieldNames = arrayfun(@(e) char(e.fieldDef.name), parentEntries, 'UniformOutput', false);
+childFieldNames  = arrayfun(@(e) char(e.fieldDef.name), childEntries,  'UniformOutput', false);
+verifyTrue(testCase,  any(strcmp(parentFieldNames, 'stays_on_parent')));
+verifyFalse(testCase, any(strcmp(parentFieldNames, 'moves_to_child')));
+verifyTrue(testCase,  any(strcmp(childFieldNames,  'moves_to_child')));
+verifyTrue(testCase,  any(strcmp(childFieldNames,  'own_field')));
+end
+
+function testResolvePlacementRaisesOnSubclassRedeclaration(testCase)
+% demoCollideConcrete declares a field whose name matches
+% demoCollideAbstract's placement=concrete_class field. Both would
+% land in demoCollideConcrete's block under the same name; this is
+% a hard schema error (V_gamma_SPEC.md "Field placement").
+cache = testCase.TestData.cache;
+verifyError(testCase, ...
+    @() cache.resolvePlacement('demoCollideConcrete'), ...
+    'did2:schema:placementCollision');
+end
+
+function testResolvePlacementRaisesOnConcreteClassPlacement(testCase)
+% demoBadConcrete is a concrete class declaring placement=concrete_class
+% on one of its own fields; that's a schema error.
+cache = testCase.TestData.cache;
+verifyError(testCase, ...
+    @() cache.resolvePlacement('demoBadConcrete'), ...
+    'did2:schema:placementOnConcreteClass');
+end
+
+function testBuildBlankDocumentOmitsAbstractBlockWhenAllPlaced(testCase)
+% demoPlaceConcrete inherits demoAbstractPlacement; abstract class
+% has only placement=concrete_class fields, so its block does not
+% appear on instance bodies.
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoPlaceConcrete');
+verifyTrue(testCase,  isfield(doc, 'base'));
+verifyTrue(testCase,  isfield(doc, 'demoPlaceConcrete'));
+verifyFalse(testCase, isfield(doc, 'demoAbstractPlacement'));
+% Both routed fields are present on the concrete block.
+verifyTrue(testCase, isfield(doc.demoPlaceConcrete, 'shared_field'));
+verifyTrue(testCase, isfield(doc.demoPlaceConcrete, 'own_field'));
+end
+
+function testValidateAcceptsConcretePlacedFieldOnLeafBlock(testCase)
+% Build the blank doc, fill in the required base.session_id, validate.
+% No errors expected even though shared_field comes from an abstract
+% ancestor with placement=concrete_class.
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoPlaceConcrete');
+doc.base.session_id = did.ido.unique_id();
+cache.validateDocument(doc);
+end
+
+function testValidateRejectsPhantomAbstractBlock(testCase)
+% Attach a `demoAbstractPlacement` block to a doc whose chain
+% includes that abstract class — under the placement rule it should
+% NOT have a body block — and verify the validator flags it as an
+% undeclared top-level block.
+cache = testCase.TestData.cache;
+doc = cache.buildBlankDocument('demoPlaceConcrete');
+doc.base.session_id = did.ido.unique_id();
+doc.demoAbstractPlacement = struct();
+verifyError(testCase, ...
+    @() cache.validateDocument(doc), ...
+    'did2:validation:undeclaredBlock');
+end

--- a/tests/+did2/fixtures/V_delta/demoAbstractPlacement.json
+++ b/tests/+did2/fixtures/V_delta/demoAbstractPlacement.json
@@ -1,0 +1,31 @@
+{
+    "document_class": {
+        "class_name": "demoAbstractPlacement",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            }
+        ],
+        "maturity_level": "stable",
+        "abstract": true
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "shared_field",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "placement": "concrete_class",
+            "documentation": "Demo abstract field placed on the concrete subclass's block via placement: concrete_class.",
+            "constraints": {}
+        }
+    ]
+}

--- a/tests/+did2/fixtures/V_delta/demoBadConcrete.json
+++ b/tests/+did2/fixtures/V_delta/demoBadConcrete.json
@@ -1,0 +1,30 @@
+{
+    "document_class": {
+        "class_name": "demoBadConcrete",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            }
+        ],
+        "maturity_level": "stable"
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "wrong_placement_field",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "placement": "concrete_class",
+            "documentation": "Concrete class declaring placement=concrete_class. This is invalid; resolvePlacement must raise placementOnConcreteClass.",
+            "constraints": {}
+        }
+    ]
+}

--- a/tests/+did2/fixtures/V_delta/demoCollideAbstract.json
+++ b/tests/+did2/fixtures/V_delta/demoCollideAbstract.json
@@ -1,0 +1,31 @@
+{
+    "document_class": {
+        "class_name": "demoCollideAbstract",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            }
+        ],
+        "maturity_level": "stable",
+        "abstract": true
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "collidingName",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "placement": "concrete_class",
+            "documentation": "Abstract field placed on concrete subclass; used by tests to verify subclass-redeclaration collisions are caught.",
+            "constraints": {}
+        }
+    ]
+}

--- a/tests/+did2/fixtures/V_delta/demoCollideConcrete.json
+++ b/tests/+did2/fixtures/V_delta/demoCollideConcrete.json
@@ -1,0 +1,32 @@
+{
+    "document_class": {
+        "class_name": "demoCollideConcrete",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            },
+            {
+                "class_name": "demoCollideAbstract"
+            }
+        ],
+        "maturity_level": "stable"
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "collidingName",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "documentation": "Concrete-class redeclaration of a name already placed by demoCollideAbstract. Used to verify resolvePlacement raises placementCollision.",
+            "constraints": {}
+        }
+    ]
+}

--- a/tests/+did2/fixtures/V_delta/demoMixedConcrete.json
+++ b/tests/+did2/fixtures/V_delta/demoMixedConcrete.json
@@ -1,0 +1,32 @@
+{
+    "document_class": {
+        "class_name": "demoMixedConcrete",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            },
+            {
+                "class_name": "demoMixedPlacement"
+            }
+        ],
+        "maturity_level": "stable"
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "own_field",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "documentation": "Own concrete-class field; shares its block with moves_to_child routed in by demoMixedPlacement.",
+            "constraints": {}
+        }
+    ]
+}

--- a/tests/+did2/fixtures/V_delta/demoMixedPlacement.json
+++ b/tests/+did2/fixtures/V_delta/demoMixedPlacement.json
@@ -1,0 +1,44 @@
+{
+    "document_class": {
+        "class_name": "demoMixedPlacement",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            }
+        ],
+        "maturity_level": "stable",
+        "abstract": true
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "stays_on_parent",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "documentation": "Default placement (declaring_class). Hosted on the abstract class's own body block.",
+            "constraints": {}
+        },
+        {
+            "name": "moves_to_child",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "placement": "concrete_class",
+            "documentation": "placement=concrete_class. Hosted on the concrete subclass's body block.",
+            "constraints": {}
+        }
+    ]
+}

--- a/tests/+did2/fixtures/V_delta/demoPlaceConcrete.json
+++ b/tests/+did2/fixtures/V_delta/demoPlaceConcrete.json
@@ -1,0 +1,32 @@
+{
+    "document_class": {
+        "class_name": "demoPlaceConcrete",
+        "class_version": "1.0.0",
+        "superclasses": [
+            {
+                "class_name": "base"
+            },
+            {
+                "class_name": "demoAbstractPlacement"
+            }
+        ],
+        "maturity_level": "stable"
+    },
+    "depends_on": [],
+    "file": [],
+    "fields": [
+        {
+            "name": "own_field",
+            "type": "char",
+            "blank_value": "",
+            "default_value": "",
+            "mustBeNonEmpty": false,
+            "mustBeScalar": true,
+            "mustNotHaveNaN": false,
+            "queryable": false,
+            "ontology": null,
+            "documentation": "Own field declared by the concrete demoPlaceConcrete class; shares its block with the inherited shared_field routed in by demoAbstractPlacement's placement=concrete_class declaration.",
+            "constraints": {}
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Implements the per-field `placement` attribute introduced in DID-schema [#56](https://github.com/Waltham-Data-Science/DID-schema/pull/56) (merged). Schema cache, blank-document builder, validator, ensureClassBlocks pass, and the calcCommon migrator are all updated to honor it. `calculator.input_parameters` (V_delta) now lives on the concrete calc-subclass body block — matching where every NDI writer (legacy did_v1, `ndi.element.addepoch`, `ndi.element.oneepoch`, and the mocks) puts it — and the abstract `calculator` class no longer materializes as a body block.

## Implementation

**`did2.schema.cache` — new `resolvePlacement(className)` method.** Returns `{blocksContributed, fieldsByBlock, chain}`. For each field declared anywhere in the chain, decides which block hosts it on instance bodies. Detects three classes of error at class-cache build time as hard schema errors:

| Error | When |
|---|---|
| `did2:schema:invalidPlacement` | `placement` value is not in `{declaring_class, concrete_class}` |
| `did2:schema:placementOnConcreteClass` | `placement: "concrete_class"` on a field declared by a non-abstract class |
| `did2:schema:placementCollision` | Two declarations route the same field name into the same block (multi-inheritance, or subclass-redeclares-an-ancestor-placed-name) |

**`buildBlankDocument`** uses `info.blocksContributed` and the placement-resolved field list, so it no longer manufactures empty blocks for abstract classes whose fields are all `placement: "concrete_class"`. `buildBlockForClass` renamed `buildBlockFromEntries`.

**`validateDocument`** validates each contributing block against its placement-resolved field list (not just `ownFields(blockClass)`), and the strict-top-level-keys check uses `blocksContributed` ∪ `{document_class, depends_on, file, files}` — so a phantom abstract-class block on a body whose placement gives that abstract class no fields to host is now flagged as `did2:validation:undeclaredBlock`.

**`did2.convert.v1_to_v2.ensureClassBlocks`** — placement-aware. Only manufactures empty blocks for contributing chain entries. Silent no-op preserved when the cache can't resolve the class.

**`did2.convert.calcCommon`** — no longer synthesizes a `calculator` block. v1 stores `<class>.input_parameters` on the concrete subclass (same location V_delta wants), so the helper just coerces the value to a struct in place and drops the inner `depends_on`. Docstring rewritten to point at the V_gamma SPEC contract.

## Tests

- **`testMigrators.m`** — 9 calc-migrator expectations flipped. Output has `<class>.input_parameters` (struct) and `isfield(out, 'calculator') == false`. The `testCalcMigratorWrappersAllResolve` smoke test asserts both conditions for all 9 per-class wrappers (`tuningcurve_calc`, `oridirtuning_calc`, `hartley_calc`, `contrast_sensitivity_calc`, `contrast_tuning_calc`, `spatial_frequency_tuning_calc`, `speed_tuning_calc`, `temporal_frequency_tuning_calc`, `simple_calc`).
- **`testSchemaCache.m`** — 8 new tests for `resolvePlacement` + `buildBlankDocument` + `validateDocument`:
  - Default `placement: "declaring_class"` everywhere when no placement keys are set.
  - `placement: "concrete_class"` routes an abstract-class field onto the concrete leaf block; abstract class doesn't contribute a block when all its fields are routed.
  - Mixed-placement abstract class still contributes a block for its `declaring_class` fields.
  - Subclass redeclaration of a placed name raises `did2:schema:placementCollision`.
  - Concrete-class field with `placement: "concrete_class"` raises `did2:schema:placementOnConcreteClass`.
  - `buildBlankDocument` omits abstract blocks that contribute nothing.
  - `validateDocument` accepts a placement-routed field on the leaf block.
  - `validateDocument` rejects a phantom abstract-class body block.
- **Seven new fixtures** under `tests/+did2/fixtures/V_delta/`: `demoAbstractPlacement`, `demoPlaceConcrete`, `demoMixedPlacement`, `demoMixedConcrete`, `demoCollideAbstract`, `demoCollideConcrete`, `demoBadConcrete`. All use `queryable: false`, so existing `queryablePaths` test counts in `testSchemaCache.m` are unaffected.

## Cross-repo dependency chain

1. ✅ Waltham-Data-Science/DID-schema#56 — V_gamma_SPEC "Field placement" text, meta-schema `placement` key, `V_delta calculator.input_parameters` tagged. Merged.
2. **This PR** — implements the contract.
3. After merge to V2: NDI-matlab `claude/776-flip-did2-normalize-gate` (PR 803) gets a CI re-trigger and should pass `testCalcTuningCurve` and `testSimpleCalc` — expected docs will now carry `<class>.input_parameters` exactly where the in-memory calc output puts it.

## Test plan

- [ ] `runtests('did2.unittest.testSchemaCache')` — new placement tests pass; existing tests unaffected.
- [ ] `runtests('did2.unittest.testMigrators')` — all 9 calc-migrator tests reflect the placement contract.
- [ ] `runtests('did2.unittest.testConvertV1ToV2')` — dispatcher's `ensureClassBlocks` no longer pads phantom `calculator` block.
- [ ] `runtests('did2.unittest.testCorpusJH')` — discovery-mode end-to-end run against the JH corpus is unaffected.
- [ ] After merge: NDI-matlab CI on PR 803 goes green for `testCalcTuningCurve` and `testSimpleCalc`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpvUtPZGMDjVKEJkpvQekN)_