### PR TITLE
did2: retarget conversion pipeline to V_epsilon + active deprecated-family migrators

### DIFF
--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Check out did-schema (sibling, for V_delta validation)
+      - name: Check out did-schema (sibling, for V_epsilon validation)
         uses: actions/checkout@v4
         with:
           repository: Waltham-Data-Science/did-schema
@@ -44,7 +44,7 @@ jobs:
 
       - name: Export DID_SCHEMA_PATH
         run: |
-          echo "DID_SCHEMA_PATH=${GITHUB_WORKSPACE}/did-schema/schemas/V_delta/stable" \
+          echo "DID_SCHEMA_PATH=${GITHUB_WORKSPACE}/did-schema/schemas/V_epsilon" \
             >> "$GITHUB_ENV"
 
       - name: Set up MATLAB

--- a/src/did/+did/+util/compareDatabaseSummary.m
+++ b/src/did/+did/+util/compareDatabaseSummary.m
@@ -241,18 +241,30 @@ function props = getProperties(docStruct)
 end
 
 function deps = normalizeDeps(depsInput)
-    % Normalize depends_on to a consistent sortable form for comparison
-    if isstruct(depsInput)
-        deps = struct();
-        for i = 1:numel(depsInput)
-            if isfield(depsInput(i), 'name') && isfield(depsInput(i), 'value')
-                deps(i).name = depsInput(i).name;
-                deps(i).value = depsInput(i).value;
-            else
-                deps(i) = depsInput(i);
-            end
-        end
-    else
+    % Normalize depends_on to a consistent sortable form for comparison.
+    % Accepts the legacy {name, value}, the V_delta/V_epsilon
+    % {name, document_id}, and the v1 {name, id} entry shapes, mapping the
+    % reference key onto `value` so summaries built under either shape
+    % compare equal. A homogeneous {name, value} struct array is built
+    % field-by-field to avoid 'heterogeneousStrucAssignment' when entries
+    % carry dissimilar key sets.
+    if ~isstruct(depsInput)
         deps = depsInput;
+        return;
+    end
+    n = numel(depsInput);
+    deps = repmat(struct('name', '', 'value', ''), 1, n);
+    for i = 1:n
+        entry = depsInput(i);
+        if isfield(entry, 'name')
+            deps(i).name = entry.name;
+        end
+        if isfield(entry, 'document_id') && ~isempty(entry.document_id)
+            deps(i).value = entry.document_id;
+        elseif isfield(entry, 'value') && ~isempty(entry.value)
+            deps(i).value = entry.value;
+        elseif isfield(entry, 'id') && ~isempty(entry.id)
+            deps(i).value = entry.id;
+        end
     end
 end

--- a/src/did/+did2/+convert/+migrators/Contents.m
+++ b/src/did/+did2/+convert/+migrators/Contents.m
@@ -1,24 +1,66 @@
-% +migrators  Per-class did_v1 -> V_delta migrator functions.
+% +migrators  Per-class did_v1 -> active-set migrator functions.
 %
 %   Each file in this package is named after the post-universal-rename
 %   v1 class name (snake_case) and exports a single function:
 %
-%       v2Body = <class_name>(preUniversalBody)
+%       out = <class_name>(preUniversalBody)
 %
-%   The dispatcher (did2.convert.v1_to_v2) applies the universal
-%   renames first, then looks up the matching migrator by class name.
-%   If no migrator exists, the dispatcher falls back to `identity`,
-%   which returns the post-universal body unchanged.
+%   OUT is either a single body struct (1:1 rewrite) or a cell array of
+%   body structs when the migration fans out into companion documents
+%   (see the subject_interaction family below). The dispatcher
+%   (did2.convert.v1_to_v2) applies the universal renames first, then
+%   looks up the matching migrator by class name. If no migrator exists,
+%   the dispatcher falls back to `identity`, which returns the
+%   post-universal body unchanged.
 %
-%   Currently registered migrators implement the four 2.0.0-bumped
-%   classes from PLAN.md §7 plus the PRED-driven §9.6 sub-step 6d
-%   additions:
+%   subject_interaction family (V_epsilon active conversion). These
+%   migrators implement the "fully active" did_v1 -> V_epsilon
+%   conversion of the five deprecated families, per the ndi-next-steps
+%   Summer 2026/1_Ingestion proposals. They build target documents in
+%   the new observation / manipulation / annotation families and share
+%   did2.convert.interactionCommon for identity carryover, ontology_term
+%   / concentration / volume composites, and minting time_reference
+%   companions:
+%
+%     treatment           - SPLIT on name/ontology into
+%                           temperature_manipulation (thermal),
+%                           procedural_manipulation (surgical/minor; and
+%                           the Dab "...Target Location" case where
+%                           string_value is the target_structure), or
+%                           environmental_manipulation (husbandry/
+%                           sensory/behavioral). A non-empty
+%                           numeric_value is preserved as a companion
+%                           generic_scalar_observation. Records that are
+%                           not manipulations (DOB, session metadata) or
+%                           cannot be routed are quarantined (the
+%                           function throws), per the report-only-first
+%                           mandate.
+%     treatment_drug      - -> injection (kind="drug"); mixture_table ->
+%                           mixture; location -> target_structure;
+%                           administration onset/offset -> companion
+%                           utc_reference.
+%     virus_injection     - -> injection (kind="virus"); construct (+
+%                           diluent) -> mixture; location ->
+%                           target_structure; administration date ->
+%                           companion (approximate) utc_reference.
+%     treatment_transfer  - -> biological_transfer; method_* ->
+%                           inherited procedure; entity_* -> entity;
+%                           recipient_id -> subject_id; donor_id carried;
+%                           global-clock timestamp -> companion
+%                           utc_reference.
+%     subject_group       - -> subject (is_group=true), carrying the
+%                           legacy id so references resolve; an optional
+%                           member is re-expressed as a companion
+%                           group_assignment.
+%     stimulus_bath       - re-rooted under `bath`: mixture_table ->
+%                           pharmacological_manipulation.mixture;
+%                           location -> bath.location; bath.kind defaults
+%                           to "drug"; stimulus_element_id carried.
+%
+%   Other registered migrators (carried over; retargeted to the active
+%   set via the version-agnostic dispatcher):
 %
 %     identity            - default passthrough.
-%     probe_location      - collapse (ontology_name, name) -> location.
-%     treatment           - collapse (ontologyName | ontology_name,
-%                           name) -> treatment_name; pass through
-%                           numeric_value and string_value.
 %     ontology_image      - collapse (ontology_name, ontology_region)
 %                           -> region.
 %     ontology_label      - collapse (ontology_name, label_id, label)
@@ -55,14 +97,6 @@
 %                           keys and builds an endpoints array-of-records
 %                           with measurement, integer_ids, string_ids,
 %                           numeric_values per endpoint.
-%     stimulus_bath       - rename location.ontologyNode -> .node;
-%                           parse the v1 CSV mixture_table into a
-%                           mixture array-of-records; each amount is a
-%                           V_delta `concentration` composite with
-%                           source_unit / source_value preserved and
-%                           the appropriate canonical sub-field (molar,
-%                           grams_per_liter, mass_fraction,
-%                           volume_fraction) populated when computable.
 %
 %   Calculator-base wrappers (PLAN.md §9.6 sub-step 6d, 20211116-driven):
 %   each calls did2.convert.calcCommon to move v1's

--- a/src/did/+did2/+convert/+migrators/stimulus_bath.m
+++ b/src/did/+did2/+convert/+migrators/stimulus_bath.m
@@ -1,64 +1,62 @@
 function v2Body = stimulus_bath(preBody)
-%STIMULUS_BATH Migrate a did_v1 stimulus_bath body to V_delta.
+%STIMULUS_BATH Migrate a did_v1 stimulus_bath to the V_epsilon shape.
 %
-%   v1 stimulus_bath stores an ontology-typed bath location plus an
-%   inline CSV `mixture_table` listing chemicals:
+%   V_epsilon re-roots stimulus_bath as a concrete subclass of `bath`
+%   (bath <- pharmacological_manipulation <- manipulation <-
+%   subject_interaction), dropping the legacy `epochid` superclass
+%   (timing now lives in time_reference documents). The legacy fields
+%   redistribute across the inherited blocks:
 %
-%       stimulus_bath.location       - {ontologyNode, name}
-%       stimulus_bath.mixture_table  - "ontologyName,name,value,ontologyUnit,unitName\n
-%                                       <chemical_curie>,<name>,<value>,
-%                                       <unit_curie>,<unit_name>\n
-%                                       ..."
+%       pharmacological_manipulation.mixture  <- mixture_table (CSV)
+%       bath.location                         <- legacy location
+%       bath.kind                             := "drug" (default; legacy
+%                                                carries no kind — curator
+%                                                backfills vehicle/wash/
+%                                                tracer where applicable)
+%       stimulus_bath (block)                 := {} (no own fields)
+%       depends_on stimulus_element_id        <- carried forward
 %
-%   V_delta keeps `location` as an ontology_term composite (just
-%   renames `ontologyNode` -> `node`) and parses the mixture CSV
-%   into an array-of-records `mixture` field. Each chemical row
-%   becomes a record with the chemical identity as an ontology_term
-%   and the concentration as a `concentration` composite.
+%   subject_id (required on every subject_interaction) and a
+%   time_reference are not recoverable from a legacy stimulus_bath
+%   (it carried neither a subject nor a wall-clock time, only an epoch
+%   and a stimulator element); both are omitted and flagged for curator
+%   backfill. The did2 validator enforces field/block shape, not
+%   depends_on cardinality, so the document is valid in the meantime.
 %
-%   The `concentration` composite carries source_unit / source_value
-%   verbatim plus optional canonical sub-fields populated whenever
-%   the source unit is computable into them:
-%
-%       molar           (canonical for source_unit in {Molar, M,
-%                        Millimolar, mM, Micromolar, uM, μM,
-%                        Nanomolar, nM, Picomolar, pM})
-%       grams_per_liter (canonical for {g/L, g/l, grams per liter,
-%                        mg/mL, mg/ml, mg/L, mg/l, ug/mL, ug/L,
-%                        μg/mL, μg/L})
-%       mass_fraction   (canonical for {w/w, %w/w})
-%       volume_fraction (canonical for {v/v, %v/v})
-%
-%   Unknown source units leave every canonical sub-field absent but
-%   still preserve source_unit / source_value -- consumers retain
-%   the raw value and can compute canonicals later when conventions
-%   firm up.
+%   See did-schema schemas/V_epsilon/conversions/from_did_v1/stimulus_bath.md.
 
 arguments
     preBody (1,1) struct
 end
 
-v2Body = preBody;
-if ~isfield(v2Body, 'stimulus_bath') ...
-        || ~isstruct(v2Body.stimulus_bath)
-    error('did2:convert:missingBlock', ...
-        'stimulus_bath body is missing the stimulus_bath property block.');
+ic = did2.convert.interactionCommon;
+
+block = struct();
+if isfield(preBody, 'stimulus_bath') && isstruct(preBody.stimulus_bath)
+    block = preBody.stimulus_bath;
 end
 
-block = v2Body.stimulus_bath;
-
-newBlock = struct();
-newBlock.location = locationToOntologyTerm(block);
-newBlock.mixture = parseMixtureTable(block);
-v2Body.stimulus_bath = newBlock;
+mixture = ic.mixtureFromTable(getField(block, 'mixture_table', ''));
+if isempty(mixture)
+    mixture = struct('chemical', ic.ontologyTerm('', ''), ...
+        'amount', ic.concentration('', 0));
 end
 
-function term = locationToOntologyTerm(block)
-% v1 location is a sub-struct {ontologyNode, name}. After
-% universalRenames the inner field stays `ontologyNode` (the
-% snake_case pass only renames top-level block fields, not nested
-% struct fields). We rename here.
-term = struct('node', '', 'name', '');
+v2Body = struct();
+v2Body.document_class = struct('class_name', 'stimulus_bath');
+v2Body.base = ic.carryBase(preBody);
+v2Body.pharmacological_manipulation = struct('mixture', mixture);
+v2Body.bath = struct( ...
+    'kind', 'drug', ...
+    'location', locationToOntologyTerm(block, ic));
+v2Body.stimulus_bath = struct();
+v2Body.depends_on = ic.dependsOn({ ...
+    'stimulus_element_id', ic.depDocId(preBody, 'stimulus_element_id')});
+end
+
+function term = locationToOntologyTerm(block, ic)
+% Legacy location is a sub-struct {ontologyNode|node, name}.
+term = ic.ontologyTerm('', '');
 if ~isfield(block, 'location')
     return;
 end
@@ -78,132 +76,9 @@ if isfield(loc, 'name')
 end
 end
 
-function mix = parseMixtureTable(block)
-% Parse the v1 CSV mixture_table into an array-of-records. Empty
-% or missing -> 0-element struct array (schema marks the field
-% optional).
-mix = struct('chemical', {}, 'amount', {});
-if ~isfield(block, 'mixture_table')
-    return;
+function v = getField(s, name, default)
+v = default;
+if isstruct(s) && isfield(s, name) && ~isempty(s.(name))
+    v = s.(name);
 end
-raw = block.mixture_table;
-if isempty(raw); return; end
-if isstring(raw) && isscalar(raw); raw = char(raw); end
-if ~ischar(raw); return; end
-
-lines = strsplit(raw, newline);
-lines = lines(~cellfun('isempty', lines));
-if isempty(lines); return; end
-
-% Detect header row -- if its first cell is the literal
-% 'ontologyName' we skip it.
-startIdx = 1;
-firstCells = strsplit(lines{1}, ',');
-if ~isempty(firstCells) && strcmpi(strtrim(firstCells{1}), 'ontologyName')
-    startIdx = 2;
-end
-
-for k = startIdx:numel(lines)
-    cells = strsplit(lines{k}, ',');
-    cells = cellfun(@strtrim, cells, 'UniformOutput', false);
-    if numel(cells) < 5; continue; end
-    chemicalNode = cells{1};
-    chemicalName = cells{2};
-    valueStr     = cells{3};
-    unitNode     = cells{4};
-    unitName     = cells{5};
-    valueNum = parseDouble(valueStr);
-    mix(end+1) = struct( ...
-        'chemical', struct('node', chemicalNode, 'name', chemicalName), ...
-        'amount',   buildConcentration(valueNum, unitName, unitNode)); %#ok<AGROW>
-end
-end
-
-function x = parseDouble(s)
-x = NaN;
-if isempty(s); return; end
-try
-    x = str2double(s);
-catch
-    x = NaN;
-end
-if ~isnumeric(x); x = NaN; end
-end
-
-function c = buildConcentration(value, unitName, ~)
-% Build a `concentration` composite. Always populates
-% source_unit / source_value; optionally populates one or more
-% canonical sub-fields if unit_name is recognised.
-c = struct( ...
-    'approximate',  false, ...
-    'source_unit',  char(unitName), ...
-    'source_value', value);
-if isnan(value); return; end
-
-molarScale = molarScaleFor(unitName);
-if ~isnan(molarScale)
-    c.molar = value * molarScale;
-    return;
-end
-gplScale = gramsPerLiterScaleFor(unitName);
-if ~isnan(gplScale)
-    c.grams_per_liter = value * gplScale;
-    return;
-end
-if isMassFractionUnit(unitName)
-    c.mass_fraction = value;
-    return;
-end
-if isVolumeFractionUnit(unitName)
-    c.volume_fraction = value;
-    return;
-end
-% Unknown unit: leave canonicals absent; source-only.
-end
-
-function s = molarScaleFor(u)
-% Unit-table lookup for source units that convert to mol/L by a
-% pure scalar. Greek mu spellings are normalised to 'u' at the
-% caller. Unknown unit -> NaN.
-u = lower(char(u));
-switch u
-    case {'molar', 'm', 'mol/l', 'mol l-1'}
-        s = 1;
-    case {'millimolar', 'mm', 'mmol/l'}
-        s = 1e-3;
-    case {'micromolar', 'um', 'mumolar', 'umol/l'}
-        s = 1e-6;
-    case {'nanomolar', 'nm', 'nmol/l'}
-        s = 1e-9;
-    case {'picomolar', 'pm', 'pmol/l'}
-        s = 1e-12;
-    otherwise
-        s = NaN;
-end
-end
-
-function s = gramsPerLiterScaleFor(u)
-u = lower(char(u));
-switch u
-    case {'g/l', 'g l-1', 'grams per liter', 'grams per litre', 'mg/ml', 'mg ml-1'}
-        s = 1;
-    case {'mg/l', 'mg l-1'}
-        s = 1e-3;
-    case {'ug/ml', 'ug ml-1', 'mug/ml'}
-        s = 1e-3;
-    case {'ug/l', 'ug l-1'}
-        s = 1e-6;
-    otherwise
-        s = NaN;
-end
-end
-
-function tf = isMassFractionUnit(u)
-u = char(u);
-tf = any(strcmpi(u, {'w/w', '%w/w', '%(w/w)'}));
-end
-
-function tf = isVolumeFractionUnit(u)
-u = char(u);
-tf = any(strcmpi(u, {'v/v', '%v/v', '%(v/v)'}));
 end

--- a/src/did/+did2/+convert/+migrators/stimulus_bath.m
+++ b/src/did/+did2/+convert/+migrators/stimulus_bath.m
@@ -31,10 +31,11 @@ end
 
 ic = did2.convert.interactionCommon;
 
-block = struct();
-if isfield(preBody, 'stimulus_bath') && isstruct(preBody.stimulus_bath)
-    block = preBody.stimulus_bath;
+if ~isfield(preBody, 'stimulus_bath') || ~isstruct(preBody.stimulus_bath)
+    error('did2:convert:missingBlock', ...
+        'stimulus_bath body is missing the stimulus_bath property block.');
 end
+block = preBody.stimulus_bath;
 
 mixture = ic.mixtureFromTable(getField(block, 'mixture_table', ''));
 if isempty(mixture)

--- a/src/did/+did2/+convert/+migrators/subject_group.m
+++ b/src/did/+did2/+convert/+migrators/subject_group.m
@@ -1,0 +1,57 @@
+function out = subject_group(preBody)
+%SUBJECT_GROUP Migrate a did_v1 subject_group to a V_epsilon subject group.
+%
+%   The standalone subject_group class is deprecated in favor of a
+%   `subject` carrying is_group = true, with membership recorded as
+%   event-sourced `group_assignment` documents, per
+%   Placement_and_Group_Assignment_Proposal.md. This migration:
+%
+%     - rewrites the subject_group into a `subject` document with
+%       is_group = true (carrying the legacy base.id forward so that
+%       documents referencing the group resolve to the new subject), and
+%     - when the legacy subject_group names a member via its optional
+%       subject_id dependency, mints a companion `group_assignment`
+%       linking that member (subject_id) to the group (group_id), so the
+%       membership survives the move from identity-doc to event model.
+%
+%   The group_assignment's time_reference is omitted (the legacy data
+%   carries no assignment time) and flagged for curator backfill.
+%
+%   See did-schema schemas/V_epsilon/conversions/from_did_v1/subject_group.md.
+
+arguments
+    preBody (1,1) struct
+end
+
+ic = did2.convert.interactionCommon;
+
+base = ic.carryBase(preBody);
+groupId = base.id;
+
+subjBody = struct();
+subjBody.document_class = struct('class_name', 'subject');
+subjBody.base = base;
+subjBody.subject = struct( ...
+    'local_identifier', '', ...
+    'description', '', ...
+    'is_biological', false, ...
+    'is_group', true);
+% subject (v2.0.0) carries no depends_on; the legacy subject_id member
+% link is re-expressed as a group_assignment companion below.
+subjBody.depends_on = ic.dependsOn(cell(0, 2));
+
+companions = {};
+memberId = ic.depDocId(preBody, 'subject_id');
+if ~isempty(memberId)
+    gaBody = struct();
+    gaBody.document_class = struct('class_name', 'group_assignment');
+    gaBody.base = ic.newBase(ic.sessionIdOf(preBody));
+    gaBody.group_assignment = struct('batch_id', '');
+    gaBody.depends_on = ic.dependsOn({ ...
+        'subject_id', memberId; ...
+        'group_id',   groupId});
+    companions{end+1} = gaBody;
+end
+
+out = [{subjBody}, companions];
+end

--- a/src/did/+did2/+convert/+migrators/treatment.m
+++ b/src/did/+did2/+convert/+migrators/treatment.m
@@ -108,7 +108,10 @@ end
 
 % ---- classification -------------------------------------------------
 
-function branch = classifyTreatment(name, ontologyNode, stringValue)
+function branch = classifyTreatment(name, ~, stringValue)
+% The ontology node is not used for routing (the legacy `name` carries
+% the semantic signal); it is accepted positionally for call-site
+% symmetry with the field mapping.
 n = lower(name);
 % Not a manipulation -> caller quarantines.
 if contains(n, 'date of birth') || contains(n, 'non-survival') ...

--- a/src/did/+did2/+convert/+migrators/treatment.m
+++ b/src/did/+did2/+convert/+migrators/treatment.m
@@ -1,0 +1,204 @@
+function out = treatment(preBody)
+%TREATMENT Migrate a did_v1 treatment via the V_epsilon manipulation split.
+%
+%   The legacy `treatment` catch-all (ontology_name + name +
+%   numeric_value + string_value) splits across the V_epsilon
+%   manipulation families by dispatching on its name/ontology, per
+%   Procedural_Manipulation_Proposal.md and Boundary_Mapping_Proposal.md:
+%
+%     thermal (heat/cool/temperature)         -> temperature_manipulation
+%     "...Target Location" + CURIE string_val -> procedural_manipulation
+%                                                 (string_value is the
+%                                                 target_structure, not
+%                                                 prose)
+%     surgical / minor procedures             -> procedural_manipulation
+%     husbandry / sensory / behavioral regime -> environmental_manipulation
+%
+%   A non-empty numeric_value is preserved as a companion
+%   generic_scalar_observation (the rung-2 escalation pattern) rather
+%   than dropped. string_value lands in `notes` for the procedural /
+%   environmental branches.
+%
+%   Records that are NOT manipulations (e.g. "Treatment: Date of birth",
+%   "Treatment: Non-survival experiment time") and records whose branch
+%   cannot be determined are QUARANTINED (this function throws), matching
+%   the proposal's "report-only first; curator confirms ambiguous /
+%   not-a-manipulation rows before any rewrite" mandate. Nothing is
+%   silently mis-routed.
+%
+%   manipulation_id (stale) and protocol_id are dropped per the proposal.
+%
+%   See did-schema schemas/V_epsilon/conversions/from_did_v1/treatment.md.
+
+arguments
+    preBody (1,1) struct
+end
+
+ic = did2.convert.interactionCommon;
+
+block = struct();
+if isfield(preBody, 'treatment') && isstruct(preBody.treatment)
+    block = preBody.treatment;
+end
+ontologyNode = char(getField(block, 'ontology_name', ''));
+name         = char(getField(block, 'name', ''));
+stringValue  = char(getField(block, 'string_value', ''));
+numericValue = getField(block, 'numeric_value', []);
+
+branch = classifyTreatment(name, ontologyNode, stringValue);
+
+subjectId = ic.depDocId(preBody, 'subject_id');
+% Timing is not recoverable from a legacy treatment (it carries none);
+% the time_reference is omitted and flagged for curator backfill.
+deps = ic.dependsOn({'subject_id', subjectId});
+
+primary = struct();
+primary.base = ic.carryBase(preBody);
+primary.depends_on = deps;
+
+switch branch
+    case 'temperature'
+        primary.document_class = struct('class_name', 'temperature_manipulation');
+        primary.scalar_manipulation = struct( ...
+            'applied_property', ic.ontologyTerm(ontologyNode, name), ...
+            'target_structure', ic.ontologyTermArray({}), ...
+            'notes', stringValue);
+        primary.temperature_manipulation = struct( ...
+            'value', struct('approximate', false, 'source_unit', '', ...
+                'source_value', firstNumeric(numericValue)));
+        numericValue = [];  % consumed into the temperature value
+    case 'procedural'
+        primary.document_class = struct('class_name', 'procedural_manipulation');
+        primary.procedural_manipulation = struct( ...
+            'procedure', ic.ontologyTerm(ontologyNode, name), ...
+            'target_structure', ic.ontologyTermArray({}), ...
+            'notes', stringValue);
+    case 'procedural_target'
+        % Dab-corpus convention: string_value is a UBERON CURIE naming
+        % the target, and the name carries a "...Target Location" suffix.
+        primary.document_class = struct('class_name', 'procedural_manipulation');
+        primary.procedural_manipulation = struct( ...
+            'procedure', ic.ontologyTerm(ontologyNode, stripTargetSuffix(name)), ...
+            'target_structure', ic.ontologyTermArray({{stringValue, ''}}), ...
+            'notes', '');
+    case 'environmental'
+        primary.document_class = struct('class_name', 'environmental_manipulation');
+        primary.environmental_manipulation = struct( ...
+            'factor', ic.ontologyTerm(ontologyNode, name), ...
+            'target_structure', ic.ontologyTermArray({}), ...
+            'notes', stringValue);
+    otherwise
+        error('did2:convert:treatmentUnrouted', ...
+            ['treatment "%s" (ontology "%s") is not a recognized ' ...
+             'manipulation branch (or is not a manipulation, e.g. a ' ...
+             'date-of-birth / session-metadata record). Route it ' ...
+             'manually per conversions/from_did_v1/treatment.md.'], ...
+            name, ontologyNode);
+end
+
+companions = {};
+% Preserve a non-empty numeric_value as a companion observation (rung 2).
+if hasNumeric(numericValue)
+    companions{end+1} = buildNumericCompanion(ic, ...
+        ontologyNode, name, numericValue, subjectId, ic.sessionIdOf(preBody));
+end
+
+out = [{primary}, companions];
+end
+
+% ---- classification -------------------------------------------------
+
+function branch = classifyTreatment(name, ontologyNode, stringValue)
+n = lower(name);
+% Not a manipulation -> caller quarantines.
+if contains(n, 'date of birth') || contains(n, 'non-survival') ...
+        || contains(n, 'experiment time')
+    branch = 'not_manipulation';
+    return;
+end
+% Dab target-location convention (string_value is an ontology CURIE).
+if endsWith(strtrim(n), 'target location') && looksLikeCurie(stringValue)
+    branch = 'procedural_target';
+    return;
+end
+if anyContains(n, {'heat', 'cool', 'cold', 'thermal', 'temperature', 'warm'})
+    branch = 'temperature';
+    return;
+end
+if anyContains(n, {'dark rear', 'rearing', 'deprivation', 'deprive', ...
+        'monocular', 'housing', 'isolation', 'enrichment', 'light cycle', ...
+        'light/dark', 'diet', 'food restrict', 'water restrict', ...
+        'social', 'training', 'exposure'})
+    branch = 'environmental';
+    return;
+end
+if anyContains(n, {'craniotomy', 'durotomy', 'implant', 'lesion', ...
+        'surgery', 'surgical', 'eye opening', 'ear notch', 'notch', ...
+        'tail clip', 'whisker trim', 'trim', 'clip', 'perfusion', ...
+        'dissection', 'transection', 'resection', 'enucleation', ...
+        'suture', 'blood draw', 'opening', 'procedure'})
+    branch = 'procedural';
+    return;
+end
+branch = 'unresolved';
+end
+
+function tf = anyContains(s, needles)
+tf = false;
+for k = 1:numel(needles)
+    if contains(s, needles{k})
+        tf = true;
+        return;
+    end
+end
+end
+
+function tf = looksLikeCurie(s)
+tf = ~isempty(regexp(char(s), '^[A-Za-z][A-Za-z0-9_]*:[A-Za-z0-9]+$', 'once'));
+end
+
+function s = stripTargetSuffix(name)
+s = regexprep(char(name), '\s*Target Location\s*$', '', 'ignorecase');
+end
+
+% ---- numeric companion ---------------------------------------------
+
+function body = buildNumericCompanion(ic, ontologyNode, name, numericValue, subjectId, sessionId)
+% A generic_scalar_observation preserving the legacy numeric value
+% verbatim (source-only), so a recognizable typed quantity is not lost.
+% The legacy base.id stays on the primary; the companion gets a fresh
+% id but the same session_id.
+body = struct();
+body.document_class = struct('class_name', 'generic_scalar_observation');
+body.base = ic.newBase(sessionId);
+body.observation = struct( ...
+    'measured_property', ic.ontologyTerm(ontologyNode, name), ...
+    'target_structure', ic.ontologyTermArray({}));
+body.generic_scalar_observation = struct('value', struct( ...
+    'approximate', true, 'source_unit', '', ...
+    'source_value', firstNumeric(numericValue)));
+body.depends_on = ic.dependsOn({'subject_id', subjectId});
+end
+
+% ---- numeric helpers -----------------------------------------------
+
+function tf = hasNumeric(v)
+tf = isnumeric(v) && ~isempty(v) && any(~isnan(v(:)));
+end
+
+function x = firstNumeric(v)
+x = 0;
+if isnumeric(v) && ~isempty(v)
+    vv = v(~isnan(v));
+    if ~isempty(vv)
+        x = vv(1);
+    end
+end
+end
+
+function val = getField(s, name, default)
+val = default;
+if isstruct(s) && isfield(s, name) && ~isempty(s.(name))
+    val = s.(name);
+end
+end

--- a/src/did/+did2/+convert/+migrators/treatment_drug.m
+++ b/src/did/+did2/+convert/+migrators/treatment_drug.m
@@ -1,0 +1,97 @@
+function out = treatment_drug(preBody)
+%TREATMENT_DRUG Migrate a did_v1 treatment_drug to a V_epsilon injection.
+%
+%   The legacy treatment_drug class (a pharmacological administration
+%   recorded as a chemical mixture at a location) maps to the V_epsilon
+%   `injection` family with kind = "drug", per Injection_Proposal.md.
+%   This migration fans out: it returns the injection document and,
+%   when the legacy administration time is recoverable, a companion
+%   utc_reference document wired as the injection's time_reference.
+%
+%   Legacy block fields (post-universalRenames snake_case):
+%     location_ontology_name / location_name - application location
+%     mixture_table                          - CSV of chemical contents
+%     administration_onset_time              - ISO onset (-> utc start)
+%     administration_offset_time             - ISO offset (-> utc end)
+%     administration_duration                - days (not retained; the
+%                                              onset/offset interval is
+%                                              the canonical timing)
+%
+%   Target injection (chain base <- subject_interaction <- manipulation
+%   <- pharmacological_manipulation <- injection):
+%     pharmacological_manipulation.mixture - from mixture_table
+%     injection.kind   = "drug"
+%     injection.volume - source-empty (legacy carries no volume)
+%     injection.route  - blank ontology_term (legacy has no route;
+%                        curator backfill)
+%     injection.target_structure - the application location as a
+%                        single-entry array when present
+%
+%   Backfill points (blank ontology nodes / empty volume) follow the
+%   draft-tier soak strategy; nothing legacy is dropped.
+%
+%   See did-schema schemas/V_epsilon/conversions/from_did_v1/treatment_drug.md.
+
+arguments
+    preBody (1,1) struct
+end
+
+ic = did2.convert.interactionCommon;
+
+block = struct();
+if isfield(preBody, 'treatment_drug') && isstruct(preBody.treatment_drug)
+    block = preBody.treatment_drug;
+end
+
+% --- mixture (required, non-empty) ---
+mixture = ic.mixtureFromTable(getField(block, 'mixture_table', ''));
+if isempty(mixture)
+    % Keep the field non-empty with one backfill placeholder so the
+    % document validates; curator supplies the chemical identity.
+    mixture = struct('chemical', ic.ontologyTerm('', ''), ...
+        'amount', ic.concentration('', 0));
+end
+
+% --- target_structure from the application location ---
+locNode = getField(block, 'location_ontology_name', '');
+locName = getField(block, 'location_name', '');
+if isempty(locNode) && isempty(locName)
+    targetStructure = ic.ontologyTermArray({});
+else
+    targetStructure = ic.ontologyTermArray({{locNode, locName}});
+end
+
+injBody = struct();
+injBody.document_class = struct('class_name', 'injection');
+injBody.base = ic.carryBase(preBody);
+injBody.pharmacological_manipulation = struct('mixture', mixture);
+injBody.injection = struct( ...
+    'kind', 'drug', ...
+    'volume', ic.volume('', 0), ...
+    'route', ic.ontologyTerm('', ''), ...
+    'target_structure', targetStructure);
+
+% --- timing: mint a utc_reference when an onset time exists ---
+onset = getField(block, 'administration_onset_time', '');
+offset = getField(block, 'administration_offset_time', '');
+companions = {};
+timeRefId = '';
+if ~isempty(onset)
+    [trBody, timeRefId] = ic.utcReferenceBody(char(onset), ...
+        ic.sessionIdOf(preBody), char(offset), false);
+    companions{end+1} = trBody;
+end
+
+injBody.depends_on = ic.dependsOn({ ...
+    'subject_id',       ic.depDocId(preBody, 'subject_id'); ...
+    'time_reference_1', timeRefId});
+
+out = [{injBody}, companions];
+end
+
+function v = getField(s, name, default)
+v = default;
+if isstruct(s) && isfield(s, name) && ~isempty(s.(name))
+    v = s.(name);
+end
+end

--- a/src/did/+did2/+convert/+migrators/treatment_transfer.m
+++ b/src/did/+did2/+convert/+migrators/treatment_transfer.m
@@ -95,9 +95,10 @@ end
 end
 
 function iso = datenumToISO(dn)
-iso = '';
 try
-    iso = [datestr(dn, 'yyyy-mm-ddTHH:MM:SS') 'Z'];
+    dt = datetime(dn, 'ConvertFrom', 'datenum');
+    dt.Format = 'yyyy-MM-dd''T''HH:mm:ss''Z''';
+    iso = char(string(dt));
 catch
     iso = '';
 end

--- a/src/did/+did2/+convert/+migrators/treatment_transfer.m
+++ b/src/did/+did2/+convert/+migrators/treatment_transfer.m
@@ -1,0 +1,111 @@
+function out = treatment_transfer(preBody)
+%TREATMENT_TRANSFER Migrate did_v1 treatment_transfer -> biological_transfer.
+%
+%   Maps the legacy donor->recipient transfer to the V_epsilon
+%   `biological_transfer` family (a procedural_manipulation subclass),
+%   per Biological_Transfer_Proposal.md. The legacy method_* pair lands
+%   on the inherited procedural_manipulation.procedure; the entity_*
+%   pair on biological_transfer.entity; the recipient becomes
+%   subject_id and the donor carries forward as donor_id. Fans out a
+%   companion utc_reference when the legacy timestamp is on a global
+%   clock.
+%
+%   Legacy block fields (post-universalRenames snake_case):
+%     timestamp (datenum if global clock, else seconds)
+%     clocktype
+%     entity_name / entity_ontology_node
+%     method_name / method_ontology_node
+%   Legacy depends_on: recipient_id (required), donor_id (optional).
+%
+%   Target biological_transfer:
+%     procedural_manipulation.procedure        = {method_ontology_node, method_name}
+%     procedural_manipulation.target_structure = [] (legacy none; backfill)
+%     procedural_manipulation.notes            = ''
+%     biological_transfer.entity               = {entity_ontology_node, entity_name}
+%     biological_transfer.kind                 = bucket(entity_name)
+%     depends_on: subject_id (<- recipient_id), donor_id, time_reference_1
+%
+%   See did-schema schemas/V_epsilon/conversions/from_did_v1/treatment_transfer.md.
+
+arguments
+    preBody (1,1) struct
+end
+
+ic = did2.convert.interactionCommon;
+
+block = struct();
+if isfield(preBody, 'treatment_transfer') && isstruct(preBody.treatment_transfer)
+    block = preBody.treatment_transfer;
+end
+
+entityName = getField(block, 'entity_name', '');
+entityNode = getField(block, 'entity_ontology_node', '');
+methodName = getField(block, 'method_name', '');
+methodNode = getField(block, 'method_ontology_node', '');
+
+btBody = struct();
+btBody.document_class = struct('class_name', 'biological_transfer');
+btBody.base = ic.carryBase(preBody);
+btBody.procedural_manipulation = struct( ...
+    'procedure', ic.ontologyTerm(methodNode, methodName), ...
+    'target_structure', ic.ontologyTermArray({}), ...
+    'notes', '');
+btBody.biological_transfer = struct( ...
+    'entity', ic.ontologyTerm(entityNode, entityName), ...
+    'kind', materialKind(entityName));
+
+% --- timing: global-clock datenum -> utc_reference ---
+timestamp = getField(block, 'timestamp', []);
+clocktype = lower(char(getField(block, 'clocktype', '')));
+companions = {};
+timeRefId = '';
+if ~isempty(timestamp) && isnumeric(timestamp) && isscalar(timestamp) ...
+        && timestamp > 0 ...
+        && (contains(clocktype, 'global') || contains(clocktype, 'utc'))
+    iso = datenumToISO(timestamp);
+    if ~isempty(iso)
+        [trBody, timeRefId] = ic.utcReferenceBody(iso, ...
+            ic.sessionIdOf(preBody), '', false);
+        companions{end+1} = trBody;
+    end
+end
+
+btBody.depends_on = ic.dependsOn({ ...
+    'subject_id',       ic.depDocId(preBody, 'recipient_id'); ...
+    'donor_id',         ic.depDocId(preBody, 'donor_id'); ...
+    'time_reference_1', timeRefId});
+
+out = [{btBody}, companions];
+end
+
+function kind = materialKind(entityName)
+% Coarse material bucket from the legacy entity name (proposal table).
+% Ambiguous/unknown defaults to "lysate" (the preparation catch-all),
+% flagged for curator confirmation in the conversion doc.
+n = lower(char(entityName));
+if contains(n, 'blood') || contains(n, 'plasma') || contains(n, 'serum')
+    kind = 'blood';
+elseif contains(n, 'cell') || contains(n, 'marrow')
+    kind = 'cells';
+elseif contains(n, 'graft') || contains(n, 'tissue') || contains(n, 'explant')
+    kind = 'tissue_graft';
+else
+    kind = 'lysate';
+end
+end
+
+function iso = datenumToISO(dn)
+iso = '';
+try
+    iso = [datestr(dn, 'yyyy-mm-ddTHH:MM:SS') 'Z'];
+catch
+    iso = '';
+end
+end
+
+function v = getField(s, name, default)
+v = default;
+if isstruct(s) && isfield(s, name) && ~isempty(s.(name))
+    v = s.(name);
+end
+end

--- a/src/did/+did2/+convert/+migrators/virus_injection.m
+++ b/src/did/+did2/+convert/+migrators/virus_injection.m
@@ -1,0 +1,100 @@
+function out = virus_injection(preBody)
+%VIRUS_INJECTION Migrate a did_v1 virus_injection to a V_epsilon injection.
+%
+%   The legacy virus_injection class maps to the V_epsilon `injection`
+%   family with kind = "virus", per Injection_Proposal.md (virus
+%   injection is NOT a biological_transfer subclass). The viral
+%   construct becomes a mixture entry; the injection location becomes
+%   target_structure; the administration date becomes a (date-only,
+%   approximate) utc_reference. This migration fans out into the
+%   injection plus the companion utc_reference when a date is present.
+%
+%   Legacy block fields (post-universalRenames snake_case):
+%     virus_ontology_name / virus_name                  - the construct
+%     virus_location_ontology_name / virus_location_name- the site
+%     virus_administration_date (YYYY-MM-DD)            - -> utc start
+%     virus_administration_pnd                          - postnatal day
+%                                                         (not timing-
+%                                                         convertible
+%                                                         without DOB;
+%                                                         backfill)
+%     dilution                                          - preserved as a
+%                                                         source-only
+%                                                         amount on the
+%                                                         construct entry
+%     diluent_ontology_name / diluent_name              - 2nd mixture
+%                                                         entry when set
+%
+%   Backfill points: blank route, empty volume (legacy carries neither),
+%   blank ontology nodes. Nothing legacy is dropped.
+%
+%   See did-schema schemas/V_epsilon/conversions/from_did_v1/virus_injection.md.
+
+arguments
+    preBody (1,1) struct
+end
+
+ic = did2.convert.interactionCommon;
+
+block = struct();
+if isfield(preBody, 'virus_injection') && isstruct(preBody.virus_injection)
+    block = preBody.virus_injection;
+end
+
+% --- mixture: construct (+ diluent) ---
+virusNode = getField(block, 'virus_ontology_name', '');
+virusName = getField(block, 'virus_name', '');
+dilution  = getField(block, 'dilution', []);
+mixture = struct( ...
+    'chemical', ic.ontologyTerm(virusNode, virusName), ...
+    'amount',   ic.concentration('dilution_factor', dilution));
+diluentNode = getField(block, 'diluent_ontology_name', '');
+diluentName = getField(block, 'diluent_name', '');
+if ~isempty(diluentNode) || ~isempty(diluentName)
+    mixture(end+1) = struct( ...
+        'chemical', ic.ontologyTerm(diluentNode, diluentName), ...
+        'amount',   ic.concentration('', 0));
+end
+
+% --- target_structure from the injection location ---
+locNode = getField(block, 'virus_location_ontology_name', '');
+locName = getField(block, 'virus_location_name', '');
+if isempty(locNode) && isempty(locName)
+    targetStructure = ic.ontologyTermArray({});
+else
+    targetStructure = ic.ontologyTermArray({{locNode, locName}});
+end
+
+injBody = struct();
+injBody.document_class = struct('class_name', 'injection');
+injBody.base = ic.carryBase(preBody);
+injBody.pharmacological_manipulation = struct('mixture', mixture);
+injBody.injection = struct( ...
+    'kind', 'virus', ...
+    'volume', ic.volume('', 0), ...
+    'route', ic.ontologyTerm('', ''), ...
+    'target_structure', targetStructure);
+
+% --- timing: date-only -> approximate utc_reference ---
+adminDate = getField(block, 'virus_administration_date', '');
+companions = {};
+timeRefId = '';
+if ~isempty(adminDate)
+    [trBody, timeRefId] = ic.utcReferenceBody(char(adminDate), ...
+        ic.sessionIdOf(preBody), '', true);
+    companions{end+1} = trBody;
+end
+
+injBody.depends_on = ic.dependsOn({ ...
+    'subject_id',       ic.depDocId(preBody, 'subject_id'); ...
+    'time_reference_1', timeRefId});
+
+out = [{injBody}, companions];
+end
+
+function v = getField(s, name, default)
+v = default;
+if isstruct(s) && isfield(s, name) && ~isempty(s.(name))
+    v = s.(name);
+end
+end

--- a/src/did/+did2/+convert/Contents.m
+++ b/src/did/+did2/+convert/Contents.m
@@ -1,11 +1,19 @@
-% +convert  did_v1 -> V_delta document conversion utilities.
+% +convert  did_v1 -> active-set document conversion utilities.
 %
 %   The +convert subpackage implements PLAN.md §7 plus the step-6
-%   sub-steps in §9.6: the v1-to-V_delta migration dispatcher, the
-%   universal-rename pass, per-class migrator functions for the
-%   four 2.0.0-bumped classes, and the legacy-database readers plus
-%   end-to-end orchestrator that drive the dispatcher off real v1
-%   database files.
+%   sub-steps in §9.6: the v1-to-active-set migration dispatcher, the
+%   universal-rename pass, per-class migrator functions, and the
+%   legacy-database readers plus end-to-end orchestrator that drive the
+%   dispatcher off real v1 database files.
+%
+%   The target schema set is whatever did2.schema.cache is pointed at —
+%   V_epsilon by default. The dispatcher reads the set-version string
+%   from the cache (index.json `schema_version_value`) and stamps it on
+%   every migrated document, so retargeting a new set version needs no
+%   code change here. Migrators may fan out (return a cell array of
+%   bodies) when a single v1 document maps to several target documents
+%   (e.g. the treatment split, subject_group -> subject + group
+%   assignments, and any interaction that mints a time_reference).
 %
 %   Files
 %     fromV1Database   - end-to-end orchestrator. Sniffs the source

--- a/src/did/+did2/+convert/interactionCommon.m
+++ b/src/did/+did2/+convert/interactionCommon.m
@@ -1,0 +1,273 @@
+classdef interactionCommon
+%INTERACTIONCOMMON Shared helpers for subject_interaction-family migrators.
+%
+%   The V_epsilon subject_interaction redesign moves the legacy
+%   treatment / treatment_drug / treatment_transfer / virus_injection /
+%   subject_group / stimulus_bath classes into the observation /
+%   manipulation / annotation families. Those migrations share a few
+%   chores that this class collects as static helpers:
+%
+%     - carrying the legacy document identity (base.id / base.datestamp)
+%       onto the primary migrated document so references survive;
+%     - reading a depends_on document_id by role name from the
+%       (already universally-renamed) legacy body;
+%     - building the target depends_on array;
+%     - minting companion time_reference documents (subject_interaction
+%       requires >=1 time_reference) and wiring them in;
+%     - building ontology_term / concentration / volume composites.
+%
+%   Timing policy. A subject_interaction requires a time_reference, but
+%   the did2 validator enforces field/block shape, not depends_on
+%   cardinality. So:
+%     - When a timestamp is recoverable from the legacy body (an ISO
+%       string, a date, a datenum), mint a utc_reference and wire it as
+%       time_reference_1.
+%     - When no timing is recoverable, omit the time_reference
+%       dependency rather than invent a sentinel timestamp. The document
+%       is valid; the missing timing is a documented curator-backfill
+%       point (see the conversions/from_did_v1/*.md for each family).
+%
+%   Ontology backfill policy. Where the legacy body carries a name but
+%   no resolvable ontology node, the helper emits {node:'', name:<name>}
+%   — a valid ontology_term whose blank node flags it for curator
+%   backfill, exactly the draft-tier soak strategy the family proposals
+%   prescribe. Nothing legacy is dropped silently.
+%
+%   See also: did2.convert.v1_to_v2 (fan-out dispatch),
+%   did2.convert.migrators.treatment / treatment_drug / virus_injection
+%   / treatment_transfer / subject_group / stimulus_bath.
+
+    methods (Static)
+        function id = mintId()
+            %MINTID Fresh DID unique id for a newly minted document.
+            id = did.ido.unique_id();
+        end
+
+        function ts = nowUTC()
+            %NOWUTC Current UTC timestamp in the did2 datestamp format.
+            dt = datetime('now', 'TimeZone', 'UTC');
+            dt.Format = 'yyyy-MM-dd''T''HH:mm:ss.SSS''Z''';
+            ts = char(string(dt));
+        end
+
+        function base = carryBase(legacyBody)
+            %CARRYBASE Base block carried from the legacy body.
+            %   Preserves base.id, base.session_id and base.datestamp
+            %   when present so the migrated primary keeps the legacy
+            %   document identity and stays in its session; mints id /
+            %   datestamp otherwise. base requires id, session_id and
+            %   datestamp (all non-empty), so session_id must come from
+            %   the source. Strict-field validation later rejects any
+            %   non-base keys, so only these are carried.
+            ic = did2.convert.interactionCommon;
+            base = struct('id', ic.mintId(), ...
+                'session_id', '', ...
+                'datestamp', ic.nowUTC());
+            if isfield(legacyBody, 'base') && isstruct(legacyBody.base) ...
+                    && isscalar(legacyBody.base)
+                lb = legacyBody.base;
+                if isfield(lb, 'id') && ~isempty(lb.id)
+                    base.id = char(lb.id);
+                end
+                if isfield(lb, 'session_id') && ~isempty(lb.session_id)
+                    base.session_id = char(lb.session_id);
+                end
+                if isfield(lb, 'datestamp') && ~isempty(lb.datestamp)
+                    base.datestamp = char(lb.datestamp);
+                end
+            end
+        end
+
+        function sid = sessionIdOf(legacyBody)
+            %SESSIONIDOF The source document's session_id (or '').
+            %   Companion documents minted during a fan-out belong to the
+            %   same session as the source, so they stamp this value.
+            sid = '';
+            if isfield(legacyBody, 'base') && isstruct(legacyBody.base) ...
+                    && isscalar(legacyBody.base) ...
+                    && isfield(legacyBody.base, 'session_id') ...
+                    && ~isempty(legacyBody.base.session_id)
+                sid = char(legacyBody.base.session_id);
+            end
+        end
+
+        function base = newBase(sessionId)
+            %NEWBASE Fresh base block for a minted companion document.
+            ic = did2.convert.interactionCommon;
+            base = struct('id', ic.mintId(), ...
+                'session_id', charOrEmpty(sessionId), ...
+                'datestamp', ic.nowUTC());
+        end
+
+        function docId = depDocId(legacyBody, name)
+            %DEPDOCID document_id of a depends_on entry by role name.
+            %   Returns '' when the role is absent. The legacy body has
+            %   already passed universalRenames, so entries carry
+            %   {name, document_id}.
+            docId = '';
+            if ~isfield(legacyBody, 'depends_on') ...
+                    || ~isstruct(legacyBody.depends_on) ...
+                    || isempty(legacyBody.depends_on)
+                return;
+            end
+            dep = legacyBody.depends_on;
+            for k = 1:numel(dep)
+                if isfield(dep(k), 'name') && strcmp(char(dep(k).name), name)
+                    if isfield(dep(k), 'document_id')
+                        docId = char(dep(k).document_id);
+                    end
+                    return;
+                end
+            end
+        end
+
+        function dep = dependsOn(pairs)
+            %DEPENDSON Build a depends_on struct array from name/id pairs.
+            %   PAIRS is an N-by-2 cell array {name, document_id}; rows
+            %   whose document_id is empty are dropped (an absent role is
+            %   simply not asserted). Returns the canonical
+            %   {name, document_id} struct array (0x0 when none remain).
+            dep = struct('name', {}, 'document_id', {});
+            for k = 1:size(pairs, 1)
+                docId = pairs{k, 2};
+                if isempty(docId)
+                    continue;
+                end
+                dep(end+1) = struct('name', pairs{k, 1}, ...
+                    'document_id', char(docId)); %#ok<AGROW>
+            end
+        end
+
+        function term = ontologyTerm(node, name)
+            %ONTOLOGYTERM {node, name} composite (blank node => backfill).
+            term = struct('node', charOrEmpty(node), 'name', charOrEmpty(name));
+        end
+
+        function arr = ontologyTermArray(terms)
+            %ONTOLOGYTERMARRAY Array-of-ontology_term from a cell of {node,name}.
+            %   TERMS is a cell array of 1x2 {node,name} cells. Returns a
+            %   struct array (0x0 when empty) suitable for an
+            %   array-of-ontology_term field (target_structure).
+            arr = struct('node', {}, 'name', {});
+            for k = 1:numel(terms)
+                arr(end+1) = did2.convert.interactionCommon.ontologyTerm( ...
+                    terms{k}{1}, terms{k}{2}); %#ok<AGROW>
+            end
+        end
+
+        function c = concentration(sourceUnit, sourceValue)
+            %CONCENTRATION Minimal concentration composite (source-only).
+            %   Canonical sub-fields are left for curator/tooling
+            %   backfill; the source unit/value are always preserved.
+            c = struct('approximate', false, ...
+                'source_unit', charOrEmpty(sourceUnit), ...
+                'source_value', toScalarNumber(sourceValue));
+        end
+
+        function v = volume(sourceUnit, sourceValue)
+            %VOLUME Minimal volume composite (source-only).
+            v = struct('approximate', false, ...
+                'source_unit', charOrEmpty(sourceUnit), ...
+                'source_value', toScalarNumber(sourceValue));
+        end
+
+        function [trBody, trId] = utcReferenceBody(startISO, sessionId, endISO, approximate)
+            %UTCREFERENCEBODY Mint a utc_reference document body.
+            %   Returns the body and its minted id. START is required
+            %   non-empty by the schema; callers must only mint a
+            %   utc_reference when they have a real start timestamp.
+            %   SESSIONID stamps base.session_id (same session as the
+            %   source interaction).
+            arguments
+                startISO (1,:) char
+                sessionId (1,:) char = ''
+                endISO (1,:) char = ''
+                approximate (1,1) logical = false
+            end
+            ic = did2.convert.interactionCommon;
+            trBody = struct();
+            trBody.document_class = struct('class_name', 'utc_reference');
+            trBody.base = ic.newBase(sessionId);
+            trId = trBody.base.id;
+            trBody.time_reference = struct('is_approximate', approximate);
+            ref = struct('start', startISO);
+            if ~isempty(endISO)
+                ref.end = endISO;
+            end
+            trBody.utc_reference = ref;
+        end
+
+        function mix = mixtureFromTable(rawTable)
+            %MIXTUREFROMTABLE Parse a legacy CSV mixture_table to records.
+            %   The did_v1 mixture_table is
+            %       "ontologyName,name,value,ontologyUnit,unitName\n
+            %        <chem_curie>,<name>,<value>,<unit_curie>,<unit_name>..."
+            %   Returns an array of {chemical:ontology_term,
+            %   amount:concentration} records (0x0 when empty). Shared by
+            %   the injection (treatment_drug) and bath (stimulus_bath)
+            %   migrations, whose pharmacological_manipulation.mixture
+            %   field has the identical shape.
+            mix = struct('chemical', {}, 'amount', {});
+            if isempty(rawTable)
+                return;
+            end
+            if isstring(rawTable) && isscalar(rawTable)
+                rawTable = char(rawTable);
+            end
+            if ~ischar(rawTable)
+                return;
+            end
+            lines = strsplit(rawTable, newline);
+            lines = lines(~cellfun('isempty', lines));
+            if isempty(lines)
+                return;
+            end
+            startIdx = 1;
+            firstCells = strsplit(lines{1}, ',');
+            if ~isempty(firstCells) ...
+                    && strcmpi(strtrim(firstCells{1}), 'ontologyName')
+                startIdx = 2;
+            end
+            ic = did2.convert.interactionCommon;
+            for k = startIdx:numel(lines)
+                cells = strsplit(lines{k}, ',');
+                cells = cellfun(@strtrim, cells, 'UniformOutput', false);
+                if numel(cells) < 5
+                    continue;
+                end
+                mix(end+1) = struct( ...
+                    'chemical', ic.ontologyTerm(cells{1}, cells{2}), ...
+                    'amount',   ic.concentration(cells{5}, cells{3})); %#ok<AGROW>
+            end
+        end
+    end
+end
+
+function s = charOrEmpty(v)
+if isempty(v)
+    s = '';
+elseif ischar(v)
+    s = v;
+elseif isstring(v) && isscalar(v)
+    s = char(v);
+else
+    s = '';
+end
+end
+
+function x = toScalarNumber(v)
+if isempty(v)
+    x = 0;
+    return;
+end
+if ischar(v) || (isstring(v) && isscalar(v))
+    x = str2double(v);
+    if isnan(x); x = 0; end
+    return;
+end
+if isnumeric(v) && isscalar(v)
+    x = v;
+else
+    x = 0;
+end
+end

--- a/src/did/+did2/+convert/interactionCommon.m
+++ b/src/did/+did2/+convert/interactionCommon.m
@@ -156,12 +156,37 @@ classdef interactionCommon
         end
 
         function c = concentration(sourceUnit, sourceValue)
-            %CONCENTRATION Minimal concentration composite (source-only).
-            %   Canonical sub-fields are left for curator/tooling
-            %   backfill; the source unit/value are always preserved.
+            %CONCENTRATION concentration composite from a source unit/value.
+            %   Always preserves source_unit / source_value, and
+            %   populates one canonical sub-field (molar, grams_per_liter,
+            %   mass_fraction or volume_fraction) when the source unit is
+            %   recognised. Unknown units stay source-only (no canonical),
+            %   so consumers can backfill once conventions firm up.
+            unit = charOrEmpty(sourceUnit);
+            value = toScalarNumber(sourceValue);
             c = struct('approximate', false, ...
-                'source_unit', charOrEmpty(sourceUnit), ...
-                'source_value', toScalarNumber(sourceValue));
+                'source_unit', unit, ...
+                'source_value', value);
+            if isnan(value)
+                return;
+            end
+            molarScale = molarScaleFor(unit);
+            if ~isnan(molarScale)
+                c.molar = value * molarScale;
+                return;
+            end
+            gplScale = gramsPerLiterScaleFor(unit);
+            if ~isnan(gplScale)
+                c.grams_per_liter = value * gplScale;
+                return;
+            end
+            if isMassFractionUnit(unit)
+                c.mass_fraction = value;
+                return;
+            end
+            if isVolumeFractionUnit(unit)
+                c.volume_fraction = value;
+            end
         end
 
         function v = volume(sourceUnit, sourceValue)
@@ -270,4 +295,47 @@ if isnumeric(v) && isscalar(v)
 else
     x = 0;
 end
+end
+
+function s = molarScaleFor(u)
+% Scalar that converts a source unit to mol/L. Unknown -> NaN.
+u = lower(char(u));
+switch u
+    case {'molar', 'm', 'mol/l', 'mol l-1'}
+        s = 1;
+    case {'millimolar', 'mm', 'mmol/l'}
+        s = 1e-3;
+    case {'micromolar', 'um', 'mumolar', 'umol/l'}
+        s = 1e-6;
+    case {'nanomolar', 'nm', 'nmol/l'}
+        s = 1e-9;
+    case {'picomolar', 'pm', 'pmol/l'}
+        s = 1e-12;
+    otherwise
+        s = NaN;
+end
+end
+
+function s = gramsPerLiterScaleFor(u)
+u = lower(char(u));
+switch u
+    case {'g/l', 'g l-1', 'grams per liter', 'grams per litre', 'mg/ml', 'mg ml-1'}
+        s = 1;
+    case {'mg/l', 'mg l-1'}
+        s = 1e-3;
+    case {'ug/ml', 'ug ml-1', 'mug/ml'}
+        s = 1e-3;
+    case {'ug/l', 'ug l-1'}
+        s = 1e-6;
+    otherwise
+        s = NaN;
+end
+end
+
+function tf = isMassFractionUnit(u)
+tf = any(strcmpi(char(u), {'w/w', '%w/w', '%(w/w)'}));
+end
+
+function tf = isVolumeFractionUnit(u)
+tf = any(strcmpi(char(u), {'v/v', '%v/v', '%(v/v)'}));
 end

--- a/src/did/+did2/+convert/universalRenames.m
+++ b/src/did/+did2/+convert/universalRenames.m
@@ -1,11 +1,19 @@
 function postBody = universalRenames(preBody, options)
-%UNIVERSALRENAMES Apply did_v1 -> V_delta universal renames.
+%UNIVERSALRENAMES Apply did_v1 -> target-set universal renames.
 %
 %   POSTBODY = did2.convert.universalRenames(PREBODY) returns a copy of
 %   PREBODY with the cross-cutting transformations from
-%   did-schema/schemas/V_delta/conversions/from_did_v1/_universal_renames.md
+%   did-schema/schemas/<set>/conversions/from_did_v1/_universal_renames.md
 %   applied. Per-class migrators run after this pass and assume their
-%   input is the semi-V_delta shape produced here.
+%   input is the semi-target shape produced here.
+%
+%   The set-version string stamped onto document_class.schema_version is
+%   resolved from the active schema cache (did2.schema.cache.shared) so
+%   the pipeline targets whatever set the cache is pointed at
+%   (V_epsilon by default). Override with the 'SchemaVersion' option.
+%   These renames are otherwise set-version-independent (the underscore,
+%   snake_case, depends_on and app/base reconciliations are the same for
+%   V_delta and V_epsilon).
 %
 %   POSTBODY = did2.convert.universalRenames(PREBODY, 'RenameClassNames', false)
 %   skips the identifier-level snake_case sweep: document_class.class_name,
@@ -70,6 +78,20 @@ function postBody = universalRenames(preBody, options)
 arguments
     preBody (1,1) struct
     options.RenameClassNames (1,1) logical = true
+    options.SchemaVersion (1,:) char = ''
+end
+
+% Resolve the target set-version string once. Callers (v1_to_v2) pass
+% the active schema cache's version so the whole pipeline stamps a
+% single source of truth; when unset, fall back to the shared cache and
+% finally to 'V_delta' so the function is still usable standalone.
+targetSchemaVersion = options.SchemaVersion;
+if isempty(targetSchemaVersion)
+    try
+        targetSchemaVersion = did2.schema.cache.shared().schemaVersion();
+    catch
+        targetSchemaVersion = 'V_delta';
+    end
 end
 
 if ~isfield(preBody, 'document_class') ...
@@ -138,7 +160,7 @@ if isfield(postBody, 'base') && isstruct(postBody.base) ...
     postBody.base = rmfield(postBody.base, 'schema_version');
 end
 if ~isfield(postBody.document_class, 'schema_version')
-    postBody.document_class.schema_version = 'V_delta';
+    postBody.document_class.schema_version = targetSchemaVersion;
 end
 end
 

--- a/src/did/+did2/+convert/v1_to_v2.m
+++ b/src/did/+did2/+convert/v1_to_v2.m
@@ -1,32 +1,49 @@
 function result = v1_to_v2(v1Bodies, options)
-%V1_TO_V2 Convert did_v1 document bodies to V_delta.
+%V1_TO_V2 Convert did_v1 document bodies to the active schema set.
+%
+%   The target schema set is whatever the active did2.schema.cache is
+%   pointed at — V_epsilon by default (NDI/DID ship pointed at the
+%   V_epsilon set-version root). The function name is retained for
+%   continuity; "v2" denotes the DID/NDI 2.0 wire format, not a fixed
+%   set version. did_v1 corpora migrate straight to the active set.
 %
 %   RESULT = did2.convert.v1_to_v2(V1BODIES) takes one or more
 %   did_v1-shaped document bodies (struct, struct array, cell array, or
 %   JSON char) and runs each through this pipeline:
 %
-%     1. did2.convert.universalRenames    (cross-cutting renames)
+%     1. did2.convert.universalRenames    (cross-cutting renames;
+%        stamps document_class.schema_version with the active set
+%        version)
 %     2. matching superclass migrators under
 %        +did2.+convert.+migrators.<superclass_name>
 %     3. concrete-class migrator under
-%        +did2.+convert.+migrators.<class_name>  (identity fallback)
+%        +did2.+convert.+migrators.<class_name>  (identity fallback).
+%        A migrator may *fan out*: returning a cell array of bodies
+%        when the migration mints companion documents (e.g. a treatment
+%        split that also emits a time_reference, or a subject_group that
+%        emits a subject plus per-member group_assignments). The first
+%        returned body is the primary; the rest are companions already
+%        in target-set shape.
 %     4. ensureClassBlocks: pad empty `struct()` property blocks for
-%        every class in the V_delta inheritance chain that the v1
-%        source or the migrators did not already produce. Lets the
-%        validator pass without each migrator having to manufacture
-%        placeholder blocks for inherited classes. Silent no-op if
-%        the schema cache cannot resolve the chain.
+%        every class in the target inheritance chain that the v1
+%        source or the migrators did not already produce, and fill any
+%        unset document_class.class_version / schema_version from the
+%        schema set. Lets the validator pass without each migrator
+%        having to manufacture placeholder blocks for inherited
+%        classes. Silent no-op if the schema cache cannot resolve the
+%        chain. Runs on every produced body (primary + companions).
 %
-%   Bodies that are already V_delta-shaped
-%   (document_class.schema_version == 'V_delta' AND no v1-only
-%   underscore-prefixed top-level markers) short-circuit steps 1-3 and
-%   go straight to ensureClassBlocks + validate. Makes the converter
-%   safely re-runnable so a partial normalisation or migration run can
-%   resume after an interruption
-%   without corrupting already-converted docs.
+%   Bodies that are already target-set-shaped
+%   (document_class.schema_version == the active set version AND no
+%   v1-only underscore-prefixed top-level markers) short-circuit steps
+%   1-3 and go straight to ensureClassBlocks + validate. Makes the
+%   converter safely re-runnable so a partial normalisation or
+%   migration run can resume after an interruption without corrupting
+%   already-converted docs.
 %
 %   Documents that fail any step land in the quarantine table; nothing
-%   is silently dropped.
+%   is silently dropped. A fan-out is all-or-nothing: if any produced
+%   body fails, the whole source document quarantines.
 %
 %   The result struct has three fields:
 %     migrated   - cell array of did2.document instances that survived
@@ -82,6 +99,11 @@ end
 
 bodies = normaliseInput(v1Bodies);
 
+% Resolve the target set-version string once, from the active cache
+% (override-aware), so universalRenames stamps and the idempotency
+% short-circuit both key off a single source of truth.
+targetSchemaVersion = resolveSchemaVersion(options.SchemaCache);
+
 migrated = {};
 quarantine = struct( ...
     'original_body', {}, ...
@@ -97,10 +119,10 @@ for k = 1:numel(bodies)
     className = '<unknown>';
     try
         preBody = ensureStruct(rawBody);
-        if isAlreadyVDelta(preBody)
-            % Idempotency short-circuit: the body is already V_delta,
-            % so skip universalRenames and the per-class migrators.
-            % ensureClassBlocks still runs (it rebuilds the V_delta
+        if isAlreadyTarget(preBody, targetSchemaVersion)
+            % Idempotency short-circuit: the body is already target-set
+            % shaped, so skip universalRenames and the per-class
+            % migrators. ensureClassBlocks still runs (it rebuilds the
             % superclass chain — required) and validate still runs
             % (gate against drift). Keeps the database normalisation
             % and migration commands safely re-runnable after an
@@ -111,20 +133,39 @@ for k = 1:numel(bodies)
                     && isfield(v2Body.document_class, 'class_name')
                 className = char(v2Body.document_class.class_name);
             end
+            producedBodies = {v2Body};
         else
             postUniversalBody = did2.convert.universalRenames(preBody, ...
-                'RenameClassNames', options.RenameClassNames);
+                'RenameClassNames', options.RenameClassNames, ...
+                'SchemaVersion', targetSchemaVersion);
             className = char(postUniversalBody.document_class.class_name);
             v2Body = applySuperclassMigrators(postUniversalBody, className);
             migratorFcn = lookupMigrator(className);
-            v2Body = migratorFcn(v2Body);
+            % A migrator may fan out: returning a single body (struct)
+            % for a 1:1 rewrite, or a cell array of bodies when the
+            % migration mints companion documents (e.g. a treatment
+            % split that also emits a time_reference, or a subject_group
+            % that emits a subject plus per-member group_assignments).
+            % The first element is the primary document; the rest are
+            % companions already in target-set shape.
+            migratorOut = migratorFcn(v2Body);
+            producedBodies = normaliseMigratorOutput(migratorOut);
         end
-        v2Body = ensureClassBlocks(v2Body, options.SchemaCache);
-        doc = did2.document(v2Body);
-        if options.Validate
-            doc.validate('SchemaCache', options.SchemaCache);
+        % ensureClassBlocks + validate run per produced body; nothing is
+        % migrated unless *every* produced body passes, so a fan-out is
+        % all-or-nothing (no half-written companion sets).
+        producedDocs = cell(1, numel(producedBodies));
+        for b = 1:numel(producedBodies)
+            bodyOut = ensureClassBlocks(producedBodies{b}, options.SchemaCache);
+            docOut = did2.document(bodyOut);
+            if options.Validate
+                docOut.validate('SchemaCache', options.SchemaCache);
+            end
+            producedDocs{b} = docOut;
         end
-        migrated{end+1} = doc; %#ok<AGROW>
+        for b = 1:numel(producedDocs)
+            migrated{end+1} = producedDocs{b}; %#ok<AGROW>
+        end
         [classCountNames, classCountValues] = bumpClassCounter( ...
             classCountNames, classCountValues, className);
     catch err
@@ -197,23 +238,62 @@ else
 end
 end
 
-function tf = isAlreadyVDelta(body)
-% Return true when BODY is already a V_delta-shaped document so the
-% per-body migration loop can skip universalRenames and the per-class
-% migrators. Both conditions must hold so the short-circuit only fires
-% when we have high confidence the body is V_delta:
-%   (a) document_class.schema_version is the literal char 'V_delta'
+function v = resolveSchemaVersion(schemaCacheOverride)
+% Resolve the target set-version string the pipeline migrates *to*.
+% Prefer an explicitly supplied cache (tests), else the shared cache,
+% else the 'V_delta' back-compat default if no cache is configured.
+v = 'V_delta';
+cache = schemaCacheOverride;
+if isempty(cache)
+    try
+        cache = did2.schema.cache.shared();
+    catch
+        return;
+    end
+end
+if ~isempty(cache)
+    try
+        v = cache.schemaVersion();
+    catch
+        % leave default
+    end
+end
+end
+
+function bodies = normaliseMigratorOutput(out)
+% A migrator returns either a single body struct (1:1 rewrite) or a
+% cell array of body structs (a fan-out that mints companion docs).
+% Normalise to a cell array of scalar structs.
+if iscell(out)
+    bodies = out(:)';
+elseif isstruct(out) && isscalar(out)
+    bodies = {out};
+elseif isstruct(out)
+    bodies = arrayfun(@(i) out(i), 1:numel(out), 'UniformOutput', false);
+else
+    error('did2:convert:badMigratorOutput', ...
+        ['A migrator must return a body struct or a cell array of ' ...
+         'body structs (got %s).'], class(out));
+end
+end
+
+function tf = isAlreadyTarget(body, targetSchemaVersion)
+% Return true when BODY is already shaped for the target set version so
+% the per-body migration loop can skip universalRenames and the
+% per-class migrators. Both conditions must hold so the short-circuit
+% only fires when we have high confidence the body is target-shaped:
+%   (a) document_class.schema_version equals TARGETSCHEMAVERSION
 %       (set by the last run of universalRenames, or by the writer),
 %       AND
 %   (b) the body carries no v1-only structural markers — underscore-
 %       prefixed top-level keys (e.g., legacy _classname,
 %       _class_version) that predate the document_class header and
-%       could not survive a real V_delta build.
+%       could not survive a real target-set build.
 %
-% (a) alone would misclassify a body that was tagged V_delta out-of-
-% band but still carries legacy field shapes; (b) alone would skip
-% the bulk of v1 corpora, which do not happen to use the underscore
-% markers but still need every other v1->V_delta rewrite.
+% (a) alone would misclassify a body that was tagged out-of-band but
+% still carries legacy field shapes; (b) alone would skip the bulk of
+% v1 corpora, which do not happen to use the underscore markers but
+% still need every other v1->target rewrite.
 tf = false;
 if ~isstruct(body) || ~isscalar(body)
     return;
@@ -228,7 +308,7 @@ sv = body.document_class.schema_version;
 if isstring(sv) && isscalar(sv)
     sv = char(sv);
 end
-if ~ischar(sv) || ~strcmp(sv, 'V_delta')
+if ~ischar(sv) || ~strcmp(sv, targetSchemaVersion)
     return;
 end
 topKeys = fieldnames(body);
@@ -309,6 +389,19 @@ for k = 1:numel(ancestors)
         'class_version', char(ancDC.class_version)); %#ok<AGROW>
 end
 body.document_class.superclasses = sc;
+% Fill class_version and schema_version from the schema set when a
+% (fan-out) migrator emitted a minimal body that set only class_name.
+% Existing values are left untouched so an already-stamped body is not
+% rewritten.
+if ~isfield(body.document_class, 'class_version') ...
+        || isempty(body.document_class.class_version)
+    body.document_class.class_version = ...
+        char(cache.getClass(className).document_class.class_version);
+end
+if ~isfield(body.document_class, 'schema_version') ...
+        || isempty(body.document_class.schema_version)
+    body.document_class.schema_version = cache.schemaVersion();
+end
 end
 
 function body = applySuperclassMigrators(body, concreteClassName)

--- a/src/did/+did2/+schema/cache.m
+++ b/src/did/+did2/+schema/cache.m
@@ -25,10 +25,37 @@ classdef cache < handle
     %   `jsondecode` returns a struct with the same field names, and
     %   `jsonencode` writes them back without any rename pass.
     %
+    %   Schema-set resolution. The cache works in one of two modes,
+    %   selected automatically at construction:
+    %
+    %     index mode  - schemaPath is a set-version root directory that
+    %                   contains an `index.json` (the V_delta/V_epsilon
+    %                   layout). Classes are resolved by `class_name`
+    %                   through the index to their tier folder
+    %                   (`stable/`, `draft/`, `deprecated/`), so a set
+    %                   whose classes are spread across tiers loads
+    %                   correctly. The set-version string carried on
+    %                   every built document is read from the index's
+    %                   `schema_version_value`.
+    %     flat mode   - schemaPath is a single directory of `*.json`
+    %                   schema files with no `index.json` (the legacy
+    %                   pre-index layout, e.g. a bare `.../stable`
+    %                   folder). Classes resolve as
+    %                   `fullfile(schemaPath, [class_name '.json'])`
+    %                   and the set-version string defaults to
+    %                   'V_delta'. Retained for back-compat.
+    %
     %   did2.schema.cache Properties:
-    %       schemaPath      - filesystem path to a V_delta schema dir.
+    %       schemaPath      - filesystem path handed to the cache (a set-
+    %                         version root in index mode, a tier dir in
+    %                         flat mode).
     %       loadedClasses   - containers.Map of classname -> raw schema.
     %       curieRegistry   - parsed CURIE_lookups_meta.json contents.
+    %       schemaVersionValue - the set-version string ('V_epsilon',
+    %                         'V_delta', ...) stamped on built documents.
+    %       indexEntries    - containers.Map class_name -> struct with
+    %                         `tier`, `path`, `is_meta` (index mode only;
+    %                         empty in flat mode).
     %
     %   did2.schema.cache Static Methods:
     %       shared          - return the process-wide singleton cache.
@@ -56,6 +83,8 @@ classdef cache < handle
         schemaPath (1,:) char = ''
         loadedClasses
         curieRegistry struct = struct()
+        schemaVersionValue (1,:) char = 'V_delta'
+        indexEntries  % containers.Map class_name -> struct(tier,path,is_meta); [] in flat mode
     end
 
     methods (Access = private)
@@ -66,6 +95,8 @@ classdef cache < handle
             end
             obj.schemaPath = schemaPath;
             obj.loadedClasses = containers.Map('KeyType', 'char', 'ValueType', 'any');
+            obj.indexEntries = [];
+            obj.loadIndexIfPresent();
             obj.loadRegistry();
         end
     end
@@ -81,13 +112,22 @@ classdef cache < handle
                 s = obj.loadedClasses(className);
                 return;
             end
-            schemaFile = fullfile(obj.schemaPath, [className '.json']);
-            if ~isfile(schemaFile)
+            schemaFile = obj.classFilePath(className);
+            if isempty(schemaFile) || ~isfile(schemaFile)
                 error('did2:schema:missingClass', ...
                     'No schema file for class "%s" at %s.', className, schemaFile);
             end
             s = jsondecode(fileread(schemaFile));
             obj.loadedClasses(className) = s;
+        end
+
+        function v = schemaVersion(obj)
+            % schemaVersion - the set-version string ('V_epsilon',
+            %   'V_delta', ...) this cache stamps onto built and
+            %   migrated documents. Read from index.json's
+            %   `schema_version_value` in index mode; defaults to
+            %   'V_delta' in flat mode.
+            v = obj.schemaVersionValue;
         end
 
         function names = superclasses(obj, className)
@@ -333,6 +373,22 @@ classdef cache < handle
             %   Used by the SQLite backend at open-time so queryablePaths
             %   returns a deterministic set independent of which classes
             %   have been touched so far in this session.
+            if ~isempty(obj.indexEntries)
+                % Index mode: iterate the authoritative class list, skip
+                % meta entries, resolve each through the index.
+                names = obj.indexEntries.keys();
+                for k = 1:numel(names)
+                    name = names{k};
+                    entry = obj.indexEntries(name);
+                    if entry.is_meta
+                        continue;
+                    end
+                    if ~obj.loadedClasses.isKey(name)
+                        obj.getClass(name);  % side effect: caches the parse.
+                    end
+                end
+                return;
+            end
             if ~isfolder(obj.schemaPath)
                 return;
             end
@@ -486,7 +542,7 @@ classdef cache < handle
                 'class_name', char(schemaDC.class_name), ...
                 'class_version', char(schemaDC.class_version), ...
                 'superclasses', sc, ...
-                'schema_version', 'V_delta');
+                'schema_version', obj.schemaVersionValue);
 
             doc.depends_on = struct('name', {}, 'document_id', {});
 
@@ -686,7 +742,14 @@ classdef cache < handle
             % three '..'s land at the *sibling* of DID-matlab where a
             % did-schema checkout typically lives. (The previous two
             % '..'s expected did-schema *inside* DID-matlab.)
-            p = fullfile(toolboxDir, '..', '..', '..', 'did-schema', 'schemas', 'V_delta', 'stable');
+            %
+            % Point at the V_epsilon set-version *root* (not a tier
+            % folder): it carries an index.json, so the cache resolves
+            % classes across stable/draft/deprecated tiers and reads the
+            % set-version string from the index. (Pre-index sets like a
+            % bare `.../V_delta/stable` still work via flat mode if a
+            % caller points the cache there.)
+            p = fullfile(toolboxDir, '..', '..', '..', 'did-schema', 'schemas', 'V_epsilon');
         end
 
         function ts = currentUTCTimestamp()
@@ -736,8 +799,92 @@ classdef cache < handle
     end
 
     methods (Access = private)
+        function loadIndexIfPresent(obj)
+            % loadIndexIfPresent - detect and parse an index.json under
+            %   schemaPath. When present (index mode), populate
+            %   obj.indexEntries (class_name -> {tier, path, is_meta})
+            %   and read obj.schemaVersionValue from the index's
+            %   `schema_version_value`/`set_version`. When absent (flat
+            %   mode) leave indexEntries empty and schemaVersionValue at
+            %   its 'V_delta' back-compat default.
+            indexFile = fullfile(obj.schemaPath, 'index.json');
+            if ~isfile(indexFile)
+                return;
+            end
+            idx = jsondecode(fileread(indexFile));
+            if isfield(idx, 'schema_version_value') && ~isempty(idx.schema_version_value)
+                obj.schemaVersionValue = char(idx.schema_version_value);
+            elseif isfield(idx, 'set_version') && ~isempty(idx.set_version)
+                obj.schemaVersionValue = char(idx.set_version);
+            end
+            obj.indexEntries = containers.Map('KeyType', 'char', 'ValueType', 'any');
+            if ~isfield(idx, 'schemas') || isempty(idx.schemas)
+                return;
+            end
+            schemas = idx.schemas;
+            for k = 1:numel(schemas)
+                entry = obj.elementAt(schemas, k);
+                if ~isfield(entry, 'class_name') || isempty(entry.class_name)
+                    continue;
+                end
+                name = char(entry.class_name);
+                tier = '';
+                if isfield(entry, 'tier') && ~isempty(entry.tier)
+                    tier = char(entry.tier);
+                end
+                relPath = '';
+                if isfield(entry, 'path') && ~isempty(entry.path)
+                    relPath = char(entry.path);
+                end
+                isMeta = false;
+                if isfield(entry, 'is_meta') && ~isempty(entry.is_meta)
+                    isMeta = (islogical(entry.is_meta) && entry.is_meta) ...
+                        || (isnumeric(entry.is_meta) && entry.is_meta == 1);
+                end
+                obj.indexEntries(name) = struct( ...
+                    'tier', tier, 'path', relPath, 'is_meta', isMeta);
+            end
+        end
+
+        function p = classFilePath(obj, className)
+            % classFilePath - absolute path to a class's schema file.
+            %   Index mode: resolve through the index to the class's
+            %   tier folder under the set-version root
+            %   (fullfile(root, tier, [class '.json'])), robust to the
+            %   set being relocated (e.g. into NDI's per-user cache).
+            %   Falls back to the index `path` joined to the inferred
+            %   repo root if the tier-relative file is missing. Flat
+            %   mode: fullfile(schemaPath, [class '.json']).
+            if ~isempty(obj.indexEntries) && obj.indexEntries.isKey(className)
+                entry = obj.indexEntries(className);
+                if ~isempty(entry.tier)
+                    candidate = fullfile(obj.schemaPath, entry.tier, [className '.json']);
+                    if isfile(candidate)
+                        p = candidate;
+                        return;
+                    end
+                end
+                if ~isempty(entry.path)
+                    % index `path` is repo-root-relative; schemaPath is
+                    % <root>/schemas/<set_version>, so the repo root is
+                    % two levels up.
+                    repoRoot = fileparts(fileparts(obj.schemaPath));
+                    candidate = fullfile(repoRoot, entry.path);
+                    if isfile(candidate)
+                        p = candidate;
+                        return;
+                    end
+                end
+            end
+            p = fullfile(obj.schemaPath, [className '.json']);
+        end
+
         function loadRegistry(obj)
             registryFile = fullfile(obj.schemaPath, 'CURIE_lookups_meta.json');
+            if (~isfile(registryFile)) && ~isempty(obj.indexEntries) ...
+                    && obj.indexEntries.isKey('CURIE_lookups_meta')
+                registryFile = obj.classFilePath('CURIE_lookups_meta');
+            end
             if isfile(registryFile)
                 obj.curieRegistry = jsondecode(fileread(registryFile));
             end

--- a/tests/+did2/+unittest/testConvertV1ToV2.m
+++ b/tests/+did2/+unittest/testConvertV1ToV2.m
@@ -1,5 +1,5 @@
 function tests = testConvertV1ToV2
-%TESTCONVERTV1TOV2 Smoke tests for the did2.convert v1->V_delta dispatcher.
+%TESTCONVERTV1TOV2 Smoke tests for the did2.convert v1->active-set dispatcher.
 %
 %   Exercises the converter skeleton (PLAN.md §9.6 sub-step 6a): the
 %   dispatcher's input normalisation, the universal-rename pass, the
@@ -31,7 +31,8 @@ v1Body.base = struct( ...
 end
 
 function testUniversalRenamesSetsSchemaVersion(testCase)
-% Every v1 body picks up `document_class.schema_version = 'V_delta'`
+% Every v1 body picks up `document_class.schema_version` set to the
+% active set version (V_epsilon)
 % so the next dispatcher pass takes the short-circuit. The tag lives
 % in document_class (set-version metadata, sibling of class_name /
 % class_version / superclasses), never on the base block.
@@ -39,7 +40,7 @@ v1 = makeV1Skeleton('treatment');
 v1.treatment = struct('ontology_name', 'chebi:6015', 'name', 'isoflurane', ...
     'numeric_value', 2.0, 'string_value', '2 percent');
 out = did2.convert.universalRenames(v1);
-verifyEqual(testCase, out.document_class.schema_version, 'V_delta');
+verifyEqual(testCase, out.document_class.schema_version, 'V_epsilon');
 verifyFalse(testCase, isfield(out.base, 'schema_version'));
 end
 
@@ -90,7 +91,7 @@ out = did2.convert.universalRenames(v1);
 verifyFalse(testCase, isfield(out, 'ndi_document'));
 verifyTrue(testCase, isfield(out, 'base'));
 verifyEqual(testCase, out.base.id, 'aabb1122ccdd3344_1122334455667788');
-verifyEqual(testCase, out.document_class.schema_version, 'V_delta');
+verifyEqual(testCase, out.document_class.schema_version, 'V_epsilon');
 end
 
 function testUniversalRenamesSnakeCasesCamelClassName(testCase)
@@ -267,8 +268,8 @@ verifyEqual(testCase, doc.get('epochclocktimes.t0'), 0);
 verifyEqual(testCase, doc.get('epochclocktimes.t1'), 1.5);
 end
 
-function vDelta = makeVDeltaSkeleton(className)
-% Build a body that is already V_delta-shaped: schema_version stamped
+function vDelta = makeTargetSkeleton(className)
+% Build a body that is already target-set-shaped: schema_version stamped
 % on document_class, snake-cased class name, depends_on uses
 % `document_id` (not `id` or the earlier-draft `value`).
 vDelta = struct();
@@ -278,7 +279,7 @@ vDelta.document_class = struct( ...
     'superclasses',   struct( ...
         'class_name',    'base', ...
         'class_version', '1.0.0'), ...
-    'schema_version', 'V_delta');
+    'schema_version', 'V_epsilon');
 vDelta.depends_on = struct('name', {}, 'document_id', {});
 vDelta.base = struct( ...
     'id',         'aabb1122ccdd3344_1122334455667788', ...
@@ -295,7 +296,7 @@ function testShortCircuitOnAlreadyVDeltaBody(testCase)
 % stay verbatim because the superclass migrator never runs.
 % ensureClassBlocks still runs (rebuilds the chain) and the body
 % still becomes a did2.document.
-vDelta = makeVDeltaSkeleton('some_unregistered_class');
+vDelta = makeTargetSkeleton('some_unregistered_class');
 vDelta.some_unregistered_class = struct('foo', 'bar');
 vDelta.epochclocktimes = struct('clocktype', 'dev_local_time', ...
     't0_t1', [0 1.5]);
@@ -308,7 +309,7 @@ doc = result.migrated{1};
 verifyEqual(testCase, doc.get('epochclocktimes.clocktype'), ...
     'dev_local_time');
 verifyEqual(testCase, doc.get('epochclocktimes.t0_t1'), [0 1.5]);
-verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_delta');
+verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_epsilon');
 % Per-class summary keys off the unchanged class_name.
 verifyEqual(testCase, result.summary.by_class.some_unregistered_class, 1);
 end
@@ -333,7 +334,7 @@ verifyEqual(testCase, second.summary.migrated_count, 1);
 verifyEqual(testCase, second.summary.quarantine_count, 0);
 secondBody = second.migrated{1}.toStruct();
 
-verifyEqual(testCase, secondBody.document_class.schema_version, 'V_delta');
+verifyEqual(testCase, secondBody.document_class.schema_version, 'V_epsilon');
 verifyEqual(testCase, secondBody.epochclocktimes.epoch_clock, ...
     'dev_local_time');
 verifyEqual(testCase, secondBody.epochclocktimes.t0, 0);
@@ -346,11 +347,11 @@ function testMixedBatchOfV1AndVDeltaBodies(testCase)
 % bodies (short-circuit) migrates every document successfully.
 v1A = makeV1Skeleton('unknown_class');
 v1A.unknown_class = struct('foo', 'bar_v1');
-vDeltaA = makeVDeltaSkeleton('unknown_class');
+vDeltaA = makeTargetSkeleton('unknown_class');
 vDeltaA.unknown_class = struct('foo', 'bar_vdelta');
 v1B = makeV1Skeleton('some_other_class');
 v1B.some_other_class = struct('n', 42);
-vDeltaB = makeVDeltaSkeleton('some_other_class');
+vDeltaB = makeTargetSkeleton('some_other_class');
 vDeltaB.some_other_class = struct('n', 99);
 
 result = did2.convert.v1_to_v2( ...
@@ -366,7 +367,7 @@ verifyEqual(testCase, result.summary.by_class.some_other_class, 2);
 % V_delta bodies kept their own).
 for k = 1:numel(result.migrated)
     doc = result.migrated{k};
-    verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_delta');
+    verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_epsilon');
 end
 end
 
@@ -386,7 +387,7 @@ verifyFalse(testCase, isfield(out, 'demo_ndi'));
 verifyEqual(testCase, out.demoNDI.value, 5);
 % schema_version stamping still runs — that's the V_delta shape
 % transformation the gate flip actually needs.
-verifyEqual(testCase, out.document_class.schema_version, 'V_delta');
+verifyEqual(testCase, out.document_class.schema_version, 'V_epsilon');
 end
 
 function testUniversalRenamesRenameClassNamesFalsePreservesSuperclassNames(testCase)
@@ -478,7 +479,7 @@ result = did2.convert.v1_to_v2(v1, 'Validate', false, ...
 verifyEqual(testCase, result.summary.migrated_count, 1);
 doc = result.migrated{1};
 verifyEqual(testCase, doc.className(), 'demoNDI');
-verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_delta');
+verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_epsilon');
 end
 
 function testShortCircuitSkippedWhenSchemaVersionMissing(testCase)
@@ -498,7 +499,7 @@ result = did2.convert.v1_to_v2(v1, 'Validate', false);
 verifyEqual(testCase, result.summary.migrated_count, 1);
 doc = result.migrated{1};
 % universalRenames ran: schema_version got stamped on document_class.
-verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_delta');
+verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_epsilon');
 % universalRenames ran: depends_on(1).id was promoted to
 % .document_id, and the legacy id/version keys were dropped.
 dependsOn = doc.toStruct().depends_on;

--- a/tests/+did2/+unittest/testCorpus20211116.m
+++ b/tests/+did2/+unittest/testCorpus20211116.m
@@ -148,7 +148,8 @@ fwrite(fid, jsonencode(report, 'PrettyPrint', true));
 end
 
 function p = resolveSchemaPath()
-% Return a directory that holds V_delta `*.json` schema files, or ''
+% Return a directory that holds the active schema set (a V_epsilon
+% set-version root with index.json, or any dir of `*.json`), or ''
 % if none can be found. Probe order: DID_SCHEMA_PATH env, then the
 % sibling-checkout default (matches did2.schema.cache).
 candidates = {};
@@ -158,7 +159,7 @@ if ~isempty(envPath)
 end
 toolboxDir = did.toolboxdir();
 candidates{end+1} = fullfile(toolboxDir, '..', '..', '..', ...
-    'did-schema', 'schemas', 'V_delta', 'stable'); %#ok<AGROW>
+    'did-schema', 'schemas', 'V_epsilon'); %#ok<AGROW>
 
 p = '';
 for k = 1:numel(candidates)

--- a/tests/+did2/+unittest/testCorpusPRED.m
+++ b/tests/+did2/+unittest/testCorpusPRED.m
@@ -101,7 +101,8 @@ end
 % --- helpers ---
 
 function p = resolveSchemaPath()
-% Return a directory that holds V_delta `*.json` schema files, or '' if
+% Return a directory that holds the active schema set (a V_epsilon
+% set-version root with index.json, or any dir of `*.json`), or '' if
 % none can be found. Probe order matches the docstring above.
 candidates = {};
 envPath = getenv('DID_SCHEMA_PATH');
@@ -112,7 +113,7 @@ end
 % did-schema is a sibling of the DID-matlab checkout.
 toolboxDir = did.toolboxdir();
 candidates{end+1} = fullfile(toolboxDir, '..', '..', '..', ...
-    'did-schema', 'schemas', 'V_delta', 'stable'); %#ok<AGROW>
+    'did-schema', 'schemas', 'V_epsilon'); %#ok<AGROW>
 
 p = '';
 for k = 1:numel(candidates)

--- a/tests/+did2/+unittest/testFromV1Database.m
+++ b/tests/+did2/+unittest/testFromV1Database.m
@@ -40,7 +40,7 @@ end
 % ---- sqlite -> v2 ----
 
 function testFromSqliteRoundTripsAllDocs(testCase)
-b1 = jsonencode(makeV1Body('treatment', 'alpha'));
+b1 = jsonencode(makeV1Body('daqreader_ndr', 'alpha'));
 b2 = jsonencode(makeV1Body('ontology_image', 'beta'));
 b3 = jsonencode(makeV1Body('probe_location', 'gamma'));
 buildV1Sqlite(testCase.TestData.srcSqlite, {b1, b2, b3});
@@ -64,7 +64,7 @@ end
 % ---- dumbjsondb -> v2 ----
 
 function testFromDumbJsonRoundTripsAllDocs(testCase)
-b1 = jsonencode(makeV1Body('treatment', 'alpha'));
+b1 = jsonencode(makeV1Body('daqreader_ndr', 'alpha'));
 b2 = jsonencode(makeV1Body('ontology_image', 'beta'));
 writeDumbJsonDoc(testCase.TestData.tmpDir, 'id_alpha', 0, b1);
 writeDumbJsonDoc(testCase.TestData.tmpDir, 'id_beta',  0, b2);
@@ -86,7 +86,7 @@ end
 % ---- quarantine ----
 
 function testQuarantineFileWrittenForMalformedDoc(testCase)
-goodBody = jsonencode(makeV1Body('treatment', 'alpha'));
+goodBody = jsonencode(makeV1Body('daqreader_ndr', 'alpha'));
 malformed = 'not json {';
 buildV1Sqlite(testCase.TestData.srcSqlite, {goodBody, malformed});
 
@@ -112,7 +112,7 @@ end
 % ---- overwrite policy ----
 
 function testOverwriteFalseRefusesExistingDst(testCase)
-goodBody = jsonencode(makeV1Body('treatment', 'alpha'));
+goodBody = jsonencode(makeV1Body('daqreader_ndr', 'alpha'));
 buildV1Sqlite(testCase.TestData.srcSqlite, {goodBody});
 
 % Touch the destination so it exists before the call.
@@ -126,7 +126,7 @@ verifyError(testCase, @() did2.convert.fromV1Database( ...
 end
 
 function testOverwriteTrueReplacesExistingDst(testCase)
-goodBody = jsonencode(makeV1Body('treatment', 'alpha'));
+goodBody = jsonencode(makeV1Body('daqreader_ndr', 'alpha'));
 buildV1Sqlite(testCase.TestData.srcSqlite, {goodBody});
 
 fid = fopen(testCase.TestData.dstPath, 'w');

--- a/tests/+did2/+unittest/testMigrators.m
+++ b/tests/+did2/+unittest/testMigrators.m
@@ -1,13 +1,14 @@
 function tests = testMigrators
-%TESTMIGRATORS Per-class did_v1 -> V_delta migrator tests.
+%TESTMIGRATORS Per-class did_v1 -> V_epsilon migrator tests.
 %
-%   Exercises the four 2.0.0-bumped class migrators (PLAN.md §9.6
-%   sub-step 6c) against the worked examples in
-%   did-schema/schemas/V_delta/conversions/from_did_v1/<class>.md.
+%   Exercises the per-class migrators against the worked examples in
+%   did-schema/schemas/V_epsilon/conversions/from_did_v1/<class>.md,
+%   including the V_epsilon active conversion of the deprecated
+%   families (e.g. the `treatment` split).
 %
 %   Tests run with Validate=false on the end-to-end dispatcher case
 %   so they do not depend on the schema cache being able to resolve
-%   V_delta schemas at the test-runner working directory.
+%   schemas at the test-runner working directory.
 %
 %   Run with:
 %       results = runtests('did2.unittest.testMigrators');
@@ -42,30 +43,36 @@ verifyEqual(testCase, doc.get('probe_location.ontology_name'), 'uberon:0002436')
 verifyEqual(testCase, doc.get('probe_location.name'), 'primary visual cortex');
 end
 
-function testTreatmentSnakeCasesCamelOntologyName(testCase)
+function testTreatmentSplitsProceduralToManipulation(testCase)
+% V_epsilon actively splits the legacy `treatment` catch-all. A
+% surgical/procedural name routes to `procedural_manipulation`, with
+% the legacy ontology+name on `procedure` and string_value on `notes`.
+v1 = wrap('treatment', 'treatment', struct( ...
+    'ontologyName',  'ncit:c15329', ...
+    'name',          'craniotomy', ...
+    'numeric_value', [], ...
+    'string_value',  '5 mm window, left hemisphere'));
+out = did2.convert.v1_to_v2(v1, 'Validate', false);
+verifyEqual(testCase, out.summary.migrated_count, 1);
+doc = out.migrated{1};
+verifyEqual(testCase, doc.className(), 'procedural_manipulation');
+verifyEqual(testCase, doc.get('procedural_manipulation.procedure.node'), 'ncit:c15329');
+verifyEqual(testCase, doc.get('procedural_manipulation.procedure.name'), 'craniotomy');
+verifyEqual(testCase, doc.get('procedural_manipulation.notes'), '5 mm window, left hemisphere');
+end
+
+function testTreatmentUnresolvedQuarantines(testCase)
+% A treatment whose name matches no manipulation branch (and is not a
+% recognized non-manipulation record) is quarantined for curator
+% review rather than mis-routed (report-only-first mandate).
 v1 = wrap('treatment', 'treatment', struct( ...
     'ontologyName',  'chebi:6015', ...
     'name',          'isoflurane', ...
-    'numeric_value', 2.0, ...
-    'string_value',  '2 percent in O2'));
+    'numeric_value', [], ...
+    'string_value',  ''));
 out = did2.convert.v1_to_v2(v1, 'Validate', false);
-doc = out.migrated{1};
-verifyEqual(testCase, doc.get('treatment.ontology_name'), 'chebi:6015');
-verifyEqual(testCase, doc.get('treatment.name'), 'isoflurane');
-verifyEqual(testCase, doc.get('treatment.numeric_value'), 2.0);
-verifyEqual(testCase, doc.get('treatment.string_value'), '2 percent in O2');
-end
-
-function testTreatmentSnakeOntologyNameRoundTrips(testCase)
-v1 = wrap('treatment', 'treatment', struct( ...
-    'ontology_name', 'chebi:6015', ...
-    'name',          'isoflurane', ...
-    'numeric_value', 2.0, ...
-    'string_value',  '2 percent in O2'));
-out = did2.convert.v1_to_v2(v1, 'Validate', false);
-doc = out.migrated{1};
-verifyEqual(testCase, doc.get('treatment.ontology_name'), 'chebi:6015');
-verifyEqual(testCase, doc.get('treatment.name'), 'isoflurane');
+verifyEqual(testCase, out.summary.migrated_count, 0);
+verifyEqual(testCase, out.summary.quarantine_count, 1);
 end
 
 function testOntologyImageRenamesClassAndCollapsesFields(testCase)
@@ -113,7 +120,7 @@ verifyEqual(testCase, doc.get('probe_location.ontology_name'), ...
     'uberon:0002436');
 verifyEqual(testCase, doc.get('probe_location.name'), ...
     'primary visual cortex');
-verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_delta');
+verifyEqual(testCase, doc.get('document_class.schema_version'), 'V_epsilon');
 end
 
 function testEndToEndDispatcherForOntologyLabel(testCase)

--- a/tests/+did2/+unittest/testMigrators.m
+++ b/tests/+did2/+unittest/testMigrators.m
@@ -656,8 +656,8 @@ v1 = wrap('stimulus_bath', 'stimulus_bath', struct( ...
     'mixture_table', ''));
 out = did2.convert.migrators.stimulus_bath( ...
     did2.convert.universalRenames(v1));
-verifyEqual(testCase, out.stimulus_bath.location.node, 'NCIm:C0179246');
-verifyEqual(testCase, out.stimulus_bath.location.name, ...
+verifyEqual(testCase, out.bath.location.node, 'NCIm:C0179246');
+verifyEqual(testCase, out.bath.location.name, ...
     'Baths, Water, Laboratory');
 end
 
@@ -669,14 +669,14 @@ v1 = wrap('stimulus_bath', 'stimulus_bath', struct( ...
                        'NCIm:C1098706,arginine-vasopressin,2e-07,OM:MolarVolumeUnit,Molar' newline]));
 out = did2.convert.migrators.stimulus_bath( ...
     did2.convert.universalRenames(v1));
-verifyEqual(testCase, numel(out.stimulus_bath.mixture), 1);
-verifyEqual(testCase, out.stimulus_bath.mixture(1).chemical.node, ...
+verifyEqual(testCase, numel(out.pharmacological_manipulation.mixture), 1);
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).chemical.node, ...
     'NCIm:C1098706');
-verifyEqual(testCase, out.stimulus_bath.mixture(1).chemical.name, ...
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).chemical.name, ...
     'arginine-vasopressin');
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.source_unit, 'Molar');
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.source_value, 2e-7);
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.molar, 2e-7);
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.source_unit, 'Molar');
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.source_value, 2e-7);
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.molar, 2e-7);
 end
 
 function testStimulusBathScalesMicromolarToMolar(testCase)
@@ -686,10 +686,10 @@ v1 = wrap('stimulus_bath', 'stimulus_bath', struct( ...
                        'CHEBI:1234,sample,5,OM:Micromolar,Micromolar']));
 out = did2.convert.migrators.stimulus_bath( ...
     did2.convert.universalRenames(v1));
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.source_value, 5);
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.source_unit, ...
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.source_value, 5);
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.source_unit, ...
     'Micromolar');
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.molar, 5e-6, ...
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.molar, 5e-6, ...
     'AbsTol', 1e-15);
 end
 
@@ -701,20 +701,26 @@ v1 = wrap('stimulus_bath', 'stimulus_bath', struct( ...
 out = did2.convert.migrators.stimulus_bath( ...
     did2.convert.universalRenames(v1));
 % Unknown unit: source preserved, no canonical populated.
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.source_value, 42);
-verifyEqual(testCase, out.stimulus_bath.mixture(1).amount.source_unit, ...
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.source_value, 42);
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).amount.source_unit, ...
     'WeirdUnit');
-verifyFalse(testCase, isfield(out.stimulus_bath.mixture(1).amount, 'molar'));
-verifyFalse(testCase, isfield(out.stimulus_bath.mixture(1).amount, 'grams_per_liter'));
+verifyFalse(testCase, isfield(out.pharmacological_manipulation.mixture(1).amount, 'molar'));
+verifyFalse(testCase, isfield(out.pharmacological_manipulation.mixture(1).amount, 'grams_per_liter'));
 end
 
-function testStimulusBathEmptyMixtureTableIsZeroLengthArray(testCase)
+function testStimulusBathEmptyMixtureTablePadsBackfillEntry(testCase)
+% V_epsilon roots the mixture on pharmacological_manipulation, whose
+% `mixture` is required non-empty. An empty mixture_table (e.g. a wash
+% bath) therefore yields a single blank backfill record (blank
+% chemical/amount) rather than a zero-length array, so the document
+% stays valid; the curator fills in the chemical during the soak.
 v1 = wrap('stimulus_bath', 'stimulus_bath', struct( ...
     'location', struct('ontologyNode', 'NCIm:C0179246', 'name', 'water'), ...
     'mixture_table', ''));
 out = did2.convert.migrators.stimulus_bath( ...
     did2.convert.universalRenames(v1));
-verifyEqual(testCase, numel(out.stimulus_bath.mixture), 0);
+verifyEqual(testCase, numel(out.pharmacological_manipulation.mixture), 1);
+verifyEqual(testCase, out.pharmacological_manipulation.mixture(1).chemical.node, '');
 end
 
 function testStimulusBathMissingBlockErrors(testCase)


### PR DESCRIPTION
## Summary

Retargets the `did2` did_v1 conversion pipeline from a single flat `V_delta/stable` directory to the tiered, `index.json`-based **V_epsilon** schema set, and implements the **fully active** conversion of the five families V_epsilon deprecates/re-roots.

This is the DID-matlab half of a 3-repo change (paired with DID-schema and NDI-matlab PRs on the same branch).

## Infrastructure (commit 1)

- **`did2.schema.cache` index mode.** Pointed at a set-version *root* containing `index.json`, the cache resolves classes by `class_name` to their tier folder (`stable`/`draft`/`deprecated`) and reads the set-version string from `schema_version_value`. Flat mode (a bare tier dir, no index) is retained for back-compat and defaults to `V_delta`. `defaultSchemaPath` now points at the `V_epsilon` root.
- **Single source of truth for the version string.** `universalRenames` and `v1_to_v2` stamp `document_class.schema_version` from the active cache version (override via `SchemaVersion`); the idempotency short-circuit keys off it. Retargeting a future set is a pin change, not a code change.
- **Migrator fan-out.** A migrator may return a cell array of bodies, so one did_v1 document can mint several V_epsilon documents. `ensureClassBlocks` fills unset `class_version`/`schema_version` so fan-out migrators can emit minimal bodies. Fan-out is all-or-nothing (any failure quarantines the source).

## Active migrators (commit 2)

New shared helper `did2.convert.interactionCommon` (identity carryover incl. `session_id`, depends_on building, ontology_term/concentration/volume composites, mixture-table parsing, minting `utc_reference` companions). Migrators:

| did_v1 | V_epsilon target(s) |
|---|---|
| `treatment` | split → `temperature_`/`procedural_`/`environmental_manipulation` (+ companion `generic_scalar_observation`); non-manipulation/unresolvable records **quarantine** (report-only-first) |
| `treatment_drug` | `injection` (kind=drug) (+ `utc_reference`) |
| `virus_injection` | `injection` (kind=virus) (+ `utc_reference`) |
| `treatment_transfer` | `biological_transfer` (+ `utc_reference`) |
| `subject_group` | `subject` (is_group=true, legacy id carried) (+ `group_assignment`) |
| `stimulus_bath` | re-rooted under `bath` |

Timing is synthesized into `time_reference` companions only when recoverable; otherwise the dependency is omitted and flagged for curator backfill, never faked. Ontology nodes absent in the legacy shapes are left blank for backfill (draft-tier soak). Nothing legacy is dropped silently.

## Not done / caveats

- **Not executed.** No MATLAB/Octave was available in the authoring environment, so the migrators are reviewed-by-reading, not run. They need a test pass against a real corpus — especially timestamp formatting, composite sub-field shapes, and the `treatment` keyword routing (which the proposals want run report-only-first; the migrator quarantines anything it can't confidently route).

Routing/field-mapping specs are in the paired DID-schema PR under `schemas/V_epsilon/conversions/from_did_v1/`.

https://claude.ai/code/session_01F737KLMaAzotg1uXeZFQuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01F737KLMaAzotg1uXeZFQuX)_