### PR TITLE
[CI] Update source of codespell action

### DIFF
--- a/.github/workflows/run-codespell.yml
+++ b/.github/workflows/run-codespell.yml
@@ -7,13 +7,17 @@ on:
   pull_request:
     branches: [ "main" ]
 
+  workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  reuse-workflow-run-codespell:
-    name: Run Codespell
-    uses: ehennestad/matbox/.github/workflows/reusable_run_codespell.yml@v0.9
-    with:
-      config_file: tools/.codespellrc
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Codespell action
+        uses: codespell-project/actions-codespell@v2


### PR DESCRIPTION
Run Codespell directly from codespell-project

The matbox wrapper is deprecated, and will be removed